### PR TITLE
Moved room and token generation to separate web endpoint and added auth step

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -5,6 +5,7 @@ import { VoiceClientProvider } from "./voice-sdk-react";
 import { DemoApp } from "./DemoApp";
 
 const voiceClient = new VoiceClient({
+  baseUrl: import.meta.env.VITE_BASE_URL,
   enableMic: true,
   callbacks: {
     onConnected: () => {


### PR DESCRIPTION
@Regaddi a few things about this PR:

- We'll (later) move the authentication step to a server-side method. This is not important. I had to abstract some logic anyway, so did it whilst I was in there (also helps make the bot runner code easier to edit later)
- To run your demo, you require two vars in your `.env.local` now: `VITE_API_KEY` and `VITE_BASE_URL`, although you can omit the base url and use the default.
- We no longer return a room url, but instead just a room name. The bot runner has a set domain, so will always launch a bot to the specified room on that domain. This is mostly just to mask things on the UI, i.e. not expose a Prebuilt link etc (they won't know the domain.)
- Let me know once you'd given it a review, and I'll deploy the updated runner and bot.
