### PR TITLE
Implement screen track capabilities

### DIFF
--- a/rtvi-client-js/src/core.ts
+++ b/rtvi-client-js/src/core.ts
@@ -45,6 +45,15 @@ export type VoiceEventCallbacks = Partial<{
 
   onTrackStarted: (track: MediaStreamTrack, participant?: Participant) => void;
   onTrackStopped: (track: MediaStreamTrack, participant?: Participant) => void;
+  onScreenTrackStarted: (
+    track: MediaStreamTrack,
+    participant?: Participant
+  ) => void;
+  onScreenTrackStopped: (
+    track: MediaStreamTrack,
+    participant?: Participant
+  ) => void;
+  onScreenShareError: (errorMessage: string) => void;
   onLocalAudioLevel: (level: number) => void;
   onRemoteAudioLevel: (level: number, participant: Participant) => void;
 
@@ -125,6 +134,18 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
       onTrackStopped: (track, p) => {
         options?.callbacks?.onTrackStopped?.(track, p);
         this.emit(VoiceEvent.TrackedStopped, track, p);
+      },
+      onScreenTrackStarted: (track, p) => {
+        options?.callbacks?.onScreenTrackStarted?.(track, p);
+        this.emit(VoiceEvent.ScreenTrackStarted, track, p);
+      },
+      onScreenTrackStopped: (track, p) => {
+        options?.callbacks?.onScreenTrackStopped?.(track, p);
+        this.emit(VoiceEvent.ScreenTrackStopped, track, p);
+      },
+      onScreenShareError: (errorMessage) => {
+        options?.callbacks?.onScreenShareError?.(errorMessage);
+        this.emit(VoiceEvent.ScreenShareError, errorMessage);
       },
       onAvailableCamsUpdated: (cams) => {
         options?.callbacks?.onAvailableCamsUpdated?.(cams);
@@ -473,6 +494,18 @@ export abstract class Client extends (EventEmitter as new () => TypedEmitter<Voi
 
   public tracks() {
     return this._transport.tracks();
+  }
+
+  public startScreenShare() {
+    return this._transport.startScreenShare();
+  }
+
+  public stopScreenShare() {
+    return this._transport.stopScreenShare();
+  }
+
+  public isSharingScreen() {
+    return this._transport.isSharingScreen();
   }
 
   // ------ Config methods

--- a/rtvi-client-js/src/events.ts
+++ b/rtvi-client-js/src/events.ts
@@ -11,6 +11,7 @@ import { Participant, TransportState } from "./transport";
 export enum VoiceEvent {
   MessageError = "messageError",
   Error = "error",
+  ScreenShareError = "screenShareError",
 
   Connected = "connected",
   Disconnected = "disconnected",
@@ -24,6 +25,8 @@ export enum VoiceEvent {
   ParticipantLeft = "participantLeft",
   TrackStarted = "trackStarted",
   TrackedStopped = "trackStopped",
+  ScreenTrackStarted = "screenTrackStarted",
+  ScreenTrackStopped = "screenTrackStopped",
 
   AvailableCamsUpdated = "availableCamsUpdated",
   AvailableMicsUpdated = "availableMicsUpdated",
@@ -63,6 +66,8 @@ export type VoiceEvents = Partial<{
   participantLeft: (p: Participant) => void;
   trackStarted: (track: MediaStreamTrack, p?: Participant) => void;
   trackStopped: (track: MediaStreamTrack, p?: Participant) => void;
+  screenTrackStarted: (track: MediaStreamTrack, p?: Participant) => void;
+  screenTrackStopped: (track: MediaStreamTrack, p?: Participant) => void;
 
   availableCamsUpdated: (cams: MediaDeviceInfo[]) => void;
   availableMicsUpdated: (cams: MediaDeviceInfo[]) => void;
@@ -86,6 +91,7 @@ export type VoiceEvents = Partial<{
 
   error: (message: VoiceMessage) => void;
   messageError: (message: VoiceMessage) => void;
+  screenShareError: (errorMessage: string) => void;
 
   llmFunctionCall: (func: LLMFunctionCallData) => void;
   llmFunctionCallStart: (functionName: string) => void;

--- a/rtvi-client-js/src/transport/core.ts
+++ b/rtvi-client-js/src/transport/core.ts
@@ -21,6 +21,8 @@ export type Participant = {
 export type Tracks = {
   local: {
     audio?: MediaStreamTrack;
+    screenAudio?: MediaStreamTrack;
+    screenVideo?: MediaStreamTrack;
     video?: MediaStreamTrack;
   };
   bot?: {
@@ -78,4 +80,8 @@ export abstract class Transport {
   abstract get expiry(): number | undefined;
 
   abstract tracks(): Tracks;
+
+  abstract startScreenShare(): void;
+  abstract stopScreenShare(): void;
+  abstract isSharingScreen(): boolean;
 }

--- a/rtvi-client-react/src/VoiceClientVideo.tsx
+++ b/rtvi-client-react/src/VoiceClientVideo.tsx
@@ -13,6 +13,11 @@ interface Props
   participant: "local" | "bot";
 
   /**
+   * Defines the video track type to display. Default: 'video'.
+   */
+  trackType: "screenVideo" | "video";
+
+  /**
    * Defines whether the video should be fully contained or cover the box. Default: 'contain'.
    */
   fit?: "contain" | "cover";
@@ -36,12 +41,13 @@ export const VoiceClientVideo = forwardRef<HTMLVideoElement, Props>(
       mirror,
       onResize,
       style = {},
+      trackType = "video",
       ...props
     },
     ref
   ) {
     const videoTrack: MediaStreamTrack | null = useVoiceClientMediaTrack(
-      "video",
+      trackType,
       participant
     );
 

--- a/rtvi-client-react/src/useVoiceClientMediaTrack.ts
+++ b/rtvi-client-react/src/useVoiceClientMediaTrack.ts
@@ -11,6 +11,8 @@ type TrackType = keyof Tracks["local"];
 
 const localAudioTrackAtom = atom<MediaStreamTrack | null>(null);
 const localVideoTrackAtom = atom<MediaStreamTrack | null>(null);
+const localScreenAudioTrackAtom = atom<MediaStreamTrack | null>(null);
+const localScreenVideoTrackAtom = atom<MediaStreamTrack | null>(null);
 const botAudioTrackAtom = atom<MediaStreamTrack | null>(null);
 const botVideoTrackAtom = atom<MediaStreamTrack | null>(null);
 
@@ -18,8 +20,18 @@ const trackAtom = atomFamily<
   { local: boolean; trackType: TrackType },
   PrimitiveAtom<MediaStreamTrack | null>
 >(({ local, trackType }) => {
-  if (local)
-    return trackType === "audio" ? localAudioTrackAtom : localVideoTrackAtom;
+  if (local) {
+    switch (trackType) {
+      case "audio":
+        return localAudioTrackAtom;
+      case "screenAudio":
+        return localScreenAudioTrackAtom;
+      case "screenVideo":
+        return localScreenVideoTrackAtom;
+      case "video":
+        return localVideoTrackAtom;
+    }
+  }
   return trackType === "audio" ? botAudioTrackAtom : botVideoTrackAtom;
 });
 
@@ -57,6 +69,14 @@ export const useVoiceClientMediaTrack = (
     VoiceEvent.TrackStarted,
     useCallback((track: MediaStreamTrack, participant?: Participant) => {
       updateTrack(track, track.kind as TrackType, Boolean(participant?.local));
+    }, [])
+  );
+
+  useVoiceClientEvent(
+    VoiceEvent.ScreenTrackStarted,
+    useCallback((track: MediaStreamTrack, participant?: Participant) => {
+      const trackType = track.kind === "audio" ? "screenAudio" : "screenVideo";
+      updateTrack(track, trackType, Boolean(participant?.local));
     }, [])
   );
 


### PR DESCRIPTION
This implements screen sharing capabilities for the local participant.

**New APIs (on VoiceClient and Transport):**

- startScreenShare(): void
- stopScreenShare(): void
- isSharingScreen(): boolean

**New events:**

- onScreenTrackStarted(track: MediaStreamTrack, participant: Participant)
- onScreenTrackStopped(track: MediaStreamTrack, participant: Participant)
- onScreenShareError(errorMessage: string)

**React updates:**

- `useVoiceClientMediaTrack` now supports `screenAudio` and `screenVideo`
- `VoiceClientVideo` now accepts an optional `trackType` prop, which can be `"video" | "screenVideo"` and defaults to `"video"`

This is minimalistic support without detailed controls over the screen share. We can add configurable options for getDisplayMedia later, if we need to. For now calling `startScreenShare()` will trigger the default screen share prompt.