### PR TITLE
To support transports being created and worked with outside...

### DIFF
--- a/client-js/src/client.ts
+++ b/client-js/src/client.ts
@@ -549,12 +549,10 @@ export class RTVIClient extends RTVIEventEmitter {
 
     await this._transport.disconnect();
 
-    this._initialize();
+    this._messageDispatcher = new MessageDispatcher(this);
   }
 
   private _initialize() {
-    // Reset transport
-    this._transport = this._options.transport;
     this._transport.initialize(this._options, this.handleMessage.bind(this));
 
     // Create a new message dispatch queue for async message handling

--- a/client-js/tests/client.spec.ts
+++ b/client-js/tests/client.spec.ts
@@ -82,7 +82,7 @@ describe("RTVIClient Methods", () => {
     await client.disconnect();
 
     expect(client.connected).toBe(false);
-    expect(client.state === "disconnected").toBe(true);
+    expect(client.state).toBe("disconnected");
 
     expect(stateChanges).toEqual([
       "initializing",

--- a/client-js/tests/stubs/transport.ts
+++ b/client-js/tests/stubs/transport.ts
@@ -66,7 +66,10 @@ export class TransportStub extends Transport {
   public async disconnect(): Promise<void> {
     return new Promise<void>((resolve) => {
       this.state = "disconnecting";
-      resolve();
+      setTimeout(() => {
+        this.state = "disconnected";
+        resolve();
+      }, 100);
     });
   }
 


### PR DESCRIPTION
the existence of the RTVI client, this PR changes the use of _initialize() (and calling transport.initialize()) so that it only happens at constructor time and not also on disconnect. If a transport needs to re-initialize or reset on disconnect, it can do that as part of its own disconnect.