### PR TITLE
automatically init devices from useRTVIClientMediaDevices

### DIFF
--- a/client-react/src/useRTVIClientMediaDevices.ts
+++ b/client-react/src/useRTVIClientMediaDevices.ts
@@ -1,7 +1,7 @@
 import { RTVIEvent } from "@pipecat-ai/client-js";
 import { atom, useAtomValue } from "jotai";
 import { useAtomCallback } from "jotai/utils";
-import { useCallback } from "react";
+import { useCallback, useEffect } from "react";
 import { useRTVIClient } from "./useRTVIClient";
 import { useRTVIClientEvent } from "./useRTVIClientEvent";
 
@@ -23,6 +23,31 @@ export const useRTVIClientMediaDevices = () => {
   const selectedCam = useAtomValue(selectedCamAtom);
   const selectedMic = useAtomValue(selectedMicAtom);
   const selectedSpeaker = useAtomValue(selectedSpeakerAtom);
+
+  const initDevices = useAtomCallback(
+    useCallback(
+      async (_get, set) => {
+        if (!client) return;
+
+        const availableCams = await client.getAllCams();
+        const availableMics = await client.getAllMics();
+        const availableSpeakers = await client.getAllSpeakers();
+
+        set(availableCamsAtom, availableCams);
+        set(availableMicsAtom, availableMics);
+        set(availableSpeakersAtom, availableSpeakers);
+
+        set(selectedCamAtom, client.selectedCam);
+        set(selectedMicAtom, client.selectedMic);
+        set(selectedSpeakerAtom, client.selectedSpeaker);
+      },
+      [client]
+    )
+  );
+
+  useEffect(() => {
+    initDevices();
+  }, [initDevices]);
 
   useRTVIClientEvent(
     RTVIEvent.AvailableCamsUpdated,


### PR DESCRIPTION
Oftentimes, when conditionally rendering device-sensitive components, such as device pickers, they are prone to missing out RTVI events, specifically `AvailableXsUpdated` and `XUpdated` (X = Cam | Mic | Speaker).

To prevent those components reading from stale state, this PR adds a `useEffect` to lazily initialize device states.