### PR TITLE
add headless cam & mic toggle components

### DIFF
--- a/client-react/src/RTVIClientCamToggle.tsx
+++ b/client-react/src/RTVIClientCamToggle.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useCallback, useEffect } from "react";
+import { useRTVIClient } from "./useRTVIClient";
+
+export interface RTVIClientCamToggleProps {
+  /**
+   * Callback fired when camera state changes
+   */
+  onCamEnabledChanged?: (enabled: boolean) => void;
+
+  /**
+   * Optional prop to disable the cam toggle.
+   * When disabled, changes are not applied to the client.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Render prop that provides state and handlers to the children
+   */
+  children: (props: {
+    disabled?: boolean;
+    isCamEnabled: boolean;
+    onClick: () => void;
+  }) => React.ReactNode;
+}
+
+/**
+ * Headless component for controlling camera state
+ */
+export const RTVIClientCamToggle: React.FC<RTVIClientCamToggleProps> = ({
+  onCamEnabledChanged,
+  disabled = false,
+  children,
+}) => {
+  const client = useRTVIClient();
+
+  const [isCamEnabled, setIsCamEnabled] = useState(
+    client?.isCamEnabled ?? false
+  );
+
+  // Sync component state with client state initially
+  useEffect(() => {
+    if (!client) return;
+    setIsCamEnabled(client.isCamEnabled);
+  }, [client]);
+
+  const handleToggleCam = useCallback(() => {
+    if (disabled) return;
+
+    const newEnabledState = !isCamEnabled;
+    setIsCamEnabled(newEnabledState);
+
+    if (client) {
+      client.enableCam(newEnabledState);
+    }
+
+    if (onCamEnabledChanged) {
+      onCamEnabledChanged(newEnabledState);
+    }
+  }, [client, disabled, isCamEnabled, onCamEnabledChanged]);
+
+  return (
+    <>
+      {children({
+        isCamEnabled,
+        onClick: handleToggleCam,
+        disabled,
+      })}
+    </>
+  );
+};
+
+export default RTVIClientCamToggle;

--- a/client-react/src/RTVIClientMicToggle.tsx
+++ b/client-react/src/RTVIClientMicToggle.tsx
@@ -1,0 +1,73 @@
+import React, { useState, useCallback, useEffect } from "react";
+import { useRTVIClient } from "./useRTVIClient";
+
+export interface RTVIClientMicToggleProps {
+  /**
+   * Callback fired when microphone state changes
+   */
+  onMicEnabledChanged?: (enabled: boolean) => void;
+
+  /**
+   * Optional prop to disable the mic toggle.
+   * When disabled, changes are not applied to the client.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Render prop that provides state and handlers to the children
+   */
+  children: (props: {
+    disabled?: boolean;
+    isMicEnabled: boolean;
+    onClick: () => void;
+  }) => React.ReactNode;
+}
+
+/**
+ * Headless component for controlling microphone state
+ */
+export const RTVIClientMicToggle: React.FC<RTVIClientMicToggleProps> = ({
+  onMicEnabledChanged,
+  disabled = false,
+  children,
+}) => {
+  const client = useRTVIClient();
+
+  const [isMicEnabled, setIsMicEnabled] = useState(
+    client?.isMicEnabled ?? false
+  );
+
+  // Sync component state with client state initially
+  useEffect(() => {
+    if (!client) return;
+    setIsMicEnabled(client.isMicEnabled);
+  }, [client]);
+
+  const handleToggleMic = useCallback(() => {
+    if (disabled) return;
+
+    const newEnabledState = !isMicEnabled;
+    setIsMicEnabled(newEnabledState);
+
+    if (client) {
+      client.enableMic(newEnabledState);
+    }
+
+    if (onMicEnabledChanged) {
+      onMicEnabledChanged(newEnabledState);
+    }
+  }, [client, disabled, isMicEnabled, onMicEnabledChanged]);
+
+  return (
+    <>
+      {children({
+        isMicEnabled,
+        onClick: handleToggleMic,
+        disabled,
+      })}
+    </>
+  );
+};
+
+export default RTVIClientMicToggle;

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -5,6 +5,8 @@
  */
 
 import { RTVIClientAudio } from "./RTVIClientAudio";
+import { RTVIClientCamToggle } from "./RTVIClientCamToggle";
+import { RTVIClientMicToggle } from "./RTVIClientMicToggle";
 import { RTVIClientProvider } from "./RTVIClientProvider";
 import { RTVIClientVideo } from "./RTVIClientVideo";
 import { useRTVIClient } from "./useRTVIClient";
@@ -16,6 +18,8 @@ import { VoiceVisualizer } from "./VoiceVisualizer";
 
 export {
   RTVIClientAudio,
+  RTVIClientCamToggle,
+  RTVIClientMicToggle,
   RTVIClientProvider,
   RTVIClientVideo,
   useRTVIClient,


### PR DESCRIPTION
This PR adds two headless components to support developers in building cam & mic toggles.

Usage would look something like this:

```tsx
<RTVIClientMicToggle>
  {({ disabled, isMicEnabled, onClick }) => (
    <button disabled={disabled} onClick={onClick}>
      {isMicEnabled ? "Turn off" : "Turn on"} microphone
    </button>
  )}
</RTVIClientMicToggle>
```

This allows developers to integrate their UI library of choice while the core logic and state management remains in the library.