### PR TITLE
Fix cam/mic control initialization

### DIFF
--- a/client-react/src/useRTVIClientCamControl.ts
+++ b/client-react/src/useRTVIClientCamControl.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useRTVIClient } from "./useRTVIClient";
+import { useRTVIClientTransportState } from "./useRTVIClientTransportState";
 
 /**
  * Hook to control camera state
@@ -12,11 +13,18 @@ export const useRTVIClientCamControl = () => {
     client?.isCamEnabled ?? false
   );
 
+  const transportState = useRTVIClientTransportState();
+
   // Sync component state with client state initially
   useEffect(() => {
-    if (!client) return;
+    if (
+      !client ||
+      transportState !== "initialized" ||
+      typeof client.isCamEnabled !== "boolean"
+    )
+      return;
     setIsCamEnabled(client.isCamEnabled);
-  }, [client]);
+  }, [client, transportState]);
 
   const enableCam = useCallback(
     (enabled: boolean) => {

--- a/client-react/src/useRTVIClientMicControl.ts
+++ b/client-react/src/useRTVIClientMicControl.ts
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { useRTVIClient } from "./useRTVIClient";
+import { useRTVIClientTransportState } from "./useRTVIClientTransportState";
 
 /**
  * Hook to control microphone state
@@ -12,11 +13,18 @@ export const useRTVIClientMicControl = () => {
     client?.isMicEnabled ?? false
   );
 
+  const transportState = useRTVIClientTransportState();
+
   // Sync component state with client state initially
   useEffect(() => {
-    if (!client) return;
+    if (
+      !client ||
+      transportState !== "initialized" ||
+      typeof client.isMicEnabled !== "boolean"
+    )
+      return;
     setIsMicEnabled(client.isMicEnabled);
-  }, [client]);
+  }, [client, transportState]);
 
   const enableMic = useCallback(
     (enabled: boolean) => {


### PR DESCRIPTION
Fixes #116.

The fix isn't ideal, because we have to rely on the transport to be initialized, however this is how things currently work.
This prevents the `isCamEnabled` and `isMicEnabled` state to be initialized with `null`.