### PR TITLE
Implement event handlers map

### DIFF
--- a/client-react/src/RTVIClientProvider.tsx
+++ b/client-react/src/RTVIClientProvider.tsx
@@ -9,6 +9,8 @@ import { createStore } from "jotai";
 import { Provider as JotaiProvider } from "jotai/react";
 import React, { createContext, useCallback, useEffect, useRef } from "react";
 
+import { RTVIEventContext } from "./RTVIEventContext";
+
 export interface Props {
   client: RTVIClient;
   jotaiStore?: React.ComponentProps<typeof JotaiProvider>["store"];
@@ -96,19 +98,11 @@ export const RTVIClientProvider: React.FC<React.PropsWithChildren<Props>> = ({
   return (
     <JotaiProvider store={jotaiStore}>
       <RTVIClientContext.Provider value={{ client }}>
-        <EventContext.Provider value={{ on, off }}>
+        <RTVIEventContext.Provider value={{ on, off }}>
           {children}
-        </EventContext.Provider>
+        </RTVIEventContext.Provider>
       </RTVIClientContext.Provider>
     </JotaiProvider>
   );
 };
 RTVIClientProvider.displayName = "RTVIClientProvider";
-
-export const EventContext = createContext<{
-  on: <E extends RTVIEvent>(event: E, handler: RTVIEventHandler<E>) => void;
-  off: <E extends RTVIEvent>(event: E, handler: RTVIEventHandler<E>) => void;
-}>({
-  on: () => {},
-  off: () => {},
-});

--- a/client-react/src/RTVIEventContext.ts
+++ b/client-react/src/RTVIEventContext.ts
@@ -1,0 +1,10 @@
+import { RTVIEvent, RTVIEventHandler } from "@pipecat-ai/client-js";
+import { createContext } from "react";
+
+export const RTVIEventContext = createContext<{
+  on: <E extends RTVIEvent>(event: E, handler: RTVIEventHandler<E>) => void;
+  off: <E extends RTVIEvent>(event: E, handler: RTVIEventHandler<E>) => void;
+}>({
+  on: () => {},
+  off: () => {},
+});

--- a/client-react/src/useRTVIClientEvent.ts
+++ b/client-react/src/useRTVIClientEvent.ts
@@ -7,13 +7,13 @@
 import { RTVIEvent, RTVIEventHandler } from "@pipecat-ai/client-js";
 import { useContext, useEffect } from "react";
 
-import { EventContext } from "./RTVIClientProvider";
+import { RTVIEventContext } from "./RTVIEventContext";
 
 export const useRTVIClientEvent = <E extends RTVIEvent>(
   event: E,
   handler: RTVIEventHandler<E>
 ) => {
-  const { on, off } = useContext(EventContext);
+  const { on, off } = useContext(RTVIEventContext);
 
   useEffect(() => {
     on(event, handler);


### PR DESCRIPTION
Influenced by Daily React this implements an event handlers map to collect event handlers at the provider level. This will only register one event handler per event type and loop and execute all registered event handlers setup via `useRTVIClientEvent`.

We will have to port these changes to #117 as well.

The types are a little more difficult to handle with Pipecat's event callback definitions: they don't share a common structure, like the event callbacks in Daily, so it requires some more force-casting of types.

Fixes #122.