### PR TITLE
React: use RTVIEvent values instead of keys

### DIFF
--- a/client-react/src/RTVIClientProvider.tsx
+++ b/client-react/src/RTVIClientProvider.tsx
@@ -34,8 +34,8 @@ export const RTVIClientProvider: React.FC<React.PropsWithChildren<Props>> = ({
   useEffect(() => {
     if (!client) return;
 
-    const allEvents = Object.keys(RTVIEvent).filter((key) =>
-      isNaN(Number(key))
+    const allEvents = Object.values(RTVIEvent).filter((value) =>
+      isNaN(Number(value))
     ) as RTVIEvent[];
 
     const allHandlers: Partial<


### PR DESCRIPTION
In JS land the enum behaves pretty much like an object. The keys are uppercase and don't match the events to register for, so we have to use the values to successfully setup event listeners.

For some reason I was under the impression that `Object.keys()` on an enum would return both the keys and values. Apparently that's not true (at least when testing in Chrome).