### PR TITLE
React: consolidate cam, mic & transport state

### DIFF
--- a/client-react/src/PipecatClientProvider.tsx
+++ b/client-react/src/PipecatClientProvider.tsx
@@ -18,6 +18,7 @@ import {
   name as packageName,
   version as packageVersion,
 } from "../package.json";
+import { PipecatClientStateProvider } from "./PipecatClientState";
 import { RTVIEventContext } from "./RTVIEventContext";
 
 export interface Props {
@@ -115,7 +116,7 @@ export const PipecatClientProvider: React.FC<
     <JotaiProvider store={jotaiStore}>
       <PipecatClientContext.Provider value={{ client }}>
         <RTVIEventContext.Provider value={{ on, off }}>
-          {children}
+          <PipecatClientStateProvider>{children}</PipecatClientStateProvider>
         </RTVIEventContext.Provider>
       </PipecatClientContext.Provider>
     </JotaiProvider>

--- a/client-react/src/PipecatClientState.tsx
+++ b/client-react/src/PipecatClientState.tsx
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { RTVIEvent, TransportState } from "@pipecat-ai/client-js";
+import React, { createContext, useCallback, useState } from "react";
+
+import { usePipecatClient } from "./usePipecatClient";
+import { useRTVIClientEvent } from "./useRTVIClientEvent";
+
+export const PipecatClientCamStateContext = createContext<{
+  enableCam: (enabled: boolean) => void;
+  isCamEnabled: boolean;
+}>({
+  enableCam: () => {
+    throw new Error(
+      "RTVICamStateContext: enableCam() called outside of provider"
+    );
+  },
+  isCamEnabled: false,
+});
+export const PipecatClientMicStateContext = createContext<{
+  enableMic: (enabled: boolean) => void;
+  isMicEnabled: boolean;
+}>({
+  enableMic: () => {
+    throw new Error(
+      "RTVIMicStateContext: enableMic() called outside of provider"
+    );
+  },
+  isMicEnabled: false,
+});
+export const PipecatClientTransportStateContext =
+  createContext<TransportState>("disconnected");
+
+export const PipecatClientStateProvider: React.FC<React.PropsWithChildren> = ({
+  children,
+}) => {
+  const client = usePipecatClient();
+  const [isCamEnabled, setIsCamEnabled] = useState(false);
+  const [isMicEnabled, setIsMicEnabled] = useState(false);
+  const [transportState, setTransportState] =
+    useState<TransportState>("disconnected");
+
+  useRTVIClientEvent(RTVIEvent.TransportStateChanged, (state) => {
+    setTransportState(state);
+    if (state === "initialized" && client) {
+      setIsCamEnabled(client.isCamEnabled ?? false);
+      setIsMicEnabled(client.isMicEnabled ?? false);
+    }
+  });
+
+  const enableCam = useCallback(
+    (enabled: boolean) => {
+      setIsCamEnabled(enabled);
+      client?.enableCam?.(enabled);
+    },
+    [client]
+  );
+
+  const enableMic = useCallback(
+    (enabled: boolean) => {
+      setIsMicEnabled(enabled);
+      client?.enableMic?.(enabled);
+    },
+    [client]
+  );
+
+  return (
+    <PipecatClientTransportStateContext.Provider value={transportState}>
+      <PipecatClientCamStateContext.Provider
+        value={{ enableCam, isCamEnabled }}
+      >
+        <PipecatClientMicStateContext.Provider
+          value={{ enableMic, isMicEnabled }}
+        >
+          {children}
+        </PipecatClientMicStateContext.Provider>
+      </PipecatClientCamStateContext.Provider>
+    </PipecatClientTransportStateContext.Provider>
+  );
+};

--- a/client-react/src/PipecatClientState.tsx
+++ b/client-react/src/PipecatClientState.tsx
@@ -16,7 +16,7 @@ export const PipecatClientCamStateContext = createContext<{
 }>({
   enableCam: () => {
     throw new Error(
-      "RTVICamStateContext: enableCam() called outside of provider"
+      "PipecatClientCamStateContext: enableCam() called outside of provider"
     );
   },
   isCamEnabled: false,
@@ -27,7 +27,7 @@ export const PipecatClientMicStateContext = createContext<{
 }>({
   enableMic: () => {
     throw new Error(
-      "RTVIMicStateContext: enableMic() called outside of provider"
+      "PipecatClientMicStateContext: enableMic() called outside of provider"
     );
   },
   isMicEnabled: false,

--- a/client-react/src/RTVIEventContext.ts
+++ b/client-react/src/RTVIEventContext.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 import { RTVIEvent, RTVIEventHandler } from "@pipecat-ai/client-js";
 import { createContext } from "react";
 

--- a/client-react/src/usePipecatClientCamControl.ts
+++ b/client-react/src/usePipecatClientCamControl.ts
@@ -1,41 +1,14 @@
-import { useCallback, useEffect, useState } from "react";
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { useContext } from "react";
 
-import { usePipecatClient } from "./usePipecatClient";
-import { usePipecatClientTransportState } from "./usePipecatClientTransportState";
+import { PipecatClientCamStateContext } from "./PipecatClientState";
 
 /**
  * Hook to control camera state
  */
-export const usePipecatClientCamControl = () => {
-  const client = usePipecatClient();
-
-  const [isCamEnabled, setIsCamEnabled] = useState(
-    client?.isCamEnabled ?? false
-  );
-
-  const transportState = usePipecatClientTransportState();
-
-  // Sync component state with client state initially
-  useEffect(() => {
-    if (
-      !client ||
-      transportState !== "initialized" ||
-      typeof client.isCamEnabled !== "boolean"
-    )
-      return;
-    setIsCamEnabled(client.isCamEnabled);
-  }, [client, transportState]);
-
-  const enableCam = useCallback(
-    (enabled: boolean) => {
-      setIsCamEnabled(enabled);
-      client?.enableCam?.(enabled);
-    },
-    [client]
-  );
-
-  return {
-    enableCam,
-    isCamEnabled,
-  };
-};
+export const useRTVIClientCamControl = () =>
+  useContext(PipecatClientCamStateContext);

--- a/client-react/src/usePipecatClientCamControl.ts
+++ b/client-react/src/usePipecatClientCamControl.ts
@@ -10,5 +10,5 @@ import { PipecatClientCamStateContext } from "./PipecatClientState";
 /**
  * Hook to control camera state
  */
-export const useRTVIClientCamControl = () =>
+export const usePipecatClientCamControl = () =>
   useContext(PipecatClientCamStateContext);

--- a/client-react/src/usePipecatClientMediaDevices.ts
+++ b/client-react/src/usePipecatClientMediaDevices.ts
@@ -1,3 +1,8 @@
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 import { RTVIEvent } from "@pipecat-ai/client-js";
 import { atom, useAtomValue } from "jotai";
 import { useAtomCallback } from "jotai/utils";

--- a/client-react/src/usePipecatClientMicControl.ts
+++ b/client-react/src/usePipecatClientMicControl.ts
@@ -11,5 +11,5 @@ import { PipecatClientMicStateContext } from "./PipecatClientState";
 /**
  * Hook to control microphone state
  */
-export const useRTVIClientMicControl = () =>
+export const usePipecatClientMicControl = () =>
   useContext(PipecatClientMicStateContext);

--- a/client-react/src/usePipecatClientMicControl.ts
+++ b/client-react/src/usePipecatClientMicControl.ts
@@ -1,41 +1,15 @@
-import { useCallback, useEffect, useState } from "react";
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
 
-import { usePipecatClient } from "./usePipecatClient";
-import { usePipecatClientTransportState } from "./usePipecatClientTransportState";
+import { useContext } from "react";
+
+import { PipecatClientMicStateContext } from "./PipecatClientState";
 
 /**
  * Hook to control microphone state
  */
-export const usePipecatClientMicControl = () => {
-  const client = usePipecatClient();
-
-  const [isMicEnabled, setIsMicEnabled] = useState(
-    client?.isMicEnabled ?? false
-  );
-
-  const transportState = usePipecatClientTransportState();
-
-  // Sync component state with client state initially
-  useEffect(() => {
-    if (
-      !client ||
-      transportState !== "initialized" ||
-      typeof client.isMicEnabled !== "boolean"
-    )
-      return;
-    setIsMicEnabled(client.isMicEnabled);
-  }, [client, transportState]);
-
-  const enableMic = useCallback(
-    (enabled: boolean) => {
-      setIsMicEnabled(enabled);
-      client?.enableMic?.(enabled);
-    },
-    [client]
-  );
-
-  return {
-    enableMic,
-    isMicEnabled,
-  };
-};
+export const useRTVIClientMicControl = () =>
+  useContext(PipecatClientMicStateContext);

--- a/client-react/src/usePipecatClientTransportState.ts
+++ b/client-react/src/usePipecatClientTransportState.ts
@@ -4,17 +4,9 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { RTVIEvent, TransportState } from "@pipecat-ai/client-js";
-import { atom, useAtom } from "jotai";
+import { useContext } from "react";
 
-import { useRTVIClientEvent } from "./useRTVIClientEvent";
+import { PipecatClientTransportStateContext } from "./PipecatClientState";
 
-const transportStateAtom = atom<TransportState>("disconnected");
-
-export const usePipecatClientTransportState = () => {
-  const [transportState, setTransportState] = useAtom(transportStateAtom);
-
-  useRTVIClientEvent(RTVIEvent.TransportStateChanged, setTransportState);
-
-  return transportState;
-};
+export const useRTVIClientTransportState = () =>
+  useContext(PipecatClientTransportStateContext);

--- a/client-react/src/usePipecatClientTransportState.ts
+++ b/client-react/src/usePipecatClientTransportState.ts
@@ -8,5 +8,5 @@ import { useContext } from "react";
 
 import { PipecatClientTransportStateContext } from "./PipecatClientState";
 
-export const useRTVIClientTransportState = () =>
+export const usePipecatClientTransportState = () =>
   useContext(PipecatClientTransportStateContext);


### PR DESCRIPTION
Instead of maintaining cam, mic & transport state individually per instance these are now maintained in a surrounding `PipecatClientStateProvider` component and shared via React context.

Fixes #121.