### PR TITLE
Add support for new deviceError callback and event

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -79,6 +79,7 @@ export type RTVIEventCallbacks = Partial<{
   onCamUpdated: (cam: MediaDeviceInfo) => void;
   onMicUpdated: (mic: MediaDeviceInfo) => void;
   onSpeakerUpdated: (speaker: MediaDeviceInfo) => void;
+  onDeviceError: (error: RTVIErrors.DeviceError) => void;
   onTrackStarted: (track: MediaStreamTrack, participant?: Participant) => void;
   onTrackStopped: (track: MediaStreamTrack, participant?: Participant) => void;
   onScreenTrackStarted: (
@@ -247,6 +248,10 @@ export class PipecatClient extends RTVIEventEmitter {
       onSpeakerUpdated: (speaker) => {
         options?.callbacks?.onSpeakerUpdated?.(speaker);
         this.emit(RTVIEvent.SpeakerUpdated, speaker);
+      },
+      onDeviceError: (error) => {
+        options?.callbacks?.onDeviceError?.(error);
+        this.emit(RTVIEvent.DeviceError, error);
       },
       onBotConnected: (p) => {
         options?.callbacks?.onBotConnected?.(p);

--- a/client-js/rtvi/errors.ts
+++ b/client-js/rtvi/errors.ts
@@ -60,3 +60,35 @@ export class UnsupportedFeatureError extends RTVIError {
     this.feature = feature;
   }
 }
+
+export type DeviceArray = Array<"cam" | "mic" | "speaker">;
+export type DeviceErrorType =
+  | "cam-in-use"
+  | "mic-in-use"
+  | "cam-mic-in-use"
+  | "permissions"
+  | "undefined-mediadevices"
+  | "not-found"
+  | "constraints"
+  | "unknown";
+export type DeviceErrorDetails = Record<
+  string,
+  string | boolean | number | Error
+>;
+
+export class DeviceError extends RTVIError {
+  readonly devices: DeviceArray;
+  readonly type: DeviceErrorType;
+  readonly details: DeviceErrorDetails | undefined;
+  constructor(
+    devices: DeviceArray,
+    type: DeviceErrorType,
+    message?: string,
+    details?: DeviceErrorDetails
+  ) {
+    super(message ?? `Device error for ${devices.join(", ")}: ${type}`);
+    this.devices = devices;
+    this.type = type;
+    this.details = details;
+  }
+}

--- a/client-js/rtvi/events.ts
+++ b/client-js/rtvi/events.ts
@@ -5,6 +5,7 @@
  */
 
 import { Participant, TransportState } from "./common_types";
+import { DeviceError } from "./errors";
 import {
   BotLLMSearchResponseData,
   BotLLMTextData,
@@ -81,6 +82,7 @@ export enum RTVIEvent {
   CamUpdated = "camUpdated",
   MicUpdated = "micUpdated",
   SpeakerUpdated = "speakerUpdated",
+  DeviceError = "deviceError",
 }
 
 export type RTVIEvents = Partial<{
@@ -150,6 +152,7 @@ export type RTVIEvents = Partial<{
   camUpdated: (cam: MediaDeviceInfo) => void;
   micUpdated: (mic: MediaDeviceInfo) => void;
   speakerUpdated: (speaker: MediaDeviceInfo) => void;
+  deviceError: (error: DeviceError) => void;
 }>;
 
 export type RTVIEventHandler<E extends RTVIEvent> = E extends keyof RTVIEvents

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
     },
     "client-js": {
       "name": "@pipecat-ai/client-js",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "@types/events": "^3.0.3",


### PR DESCRIPTION
Introducing a new PipecatClient callback for receiving device errors (mic not found, permissions lacking, etc.).