### PR TITLE
Improved usability around connect()

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ const pcClient = new PipecatClient({
 });
 
 try {
-  await pcClient.connect({ endpoint: "https://your-server-side-url/connect" });
+  await pcClient.startBotAndConnect({ endpoint: "https://your-server-side-url/connect" });
 } catch (e) {
   console.error(e.message);
 }

--- a/client-js/CHANGELOG.md
+++ b/client-js/CHANGELOG.md
@@ -8,10 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 - Improved flexibility and clarity around `connect()`:
-  - Renamed `ConnectionEndpoint` to `APIEndpoint` for clarity.
+  - Renamed `ConnectionEndpoint` to `APIRequest` for clarity.
   - Deprecated use of `connect()` with a `ConnectionEndpoint` params type in favor of separating out the authorization step from the connection step. Uses of `connect()` with a `ConnectionEndpoint` should be updated to call `startBotAndConnect()` instead. See below.  `connect()` now performs only the portion of the logic for connecting the transport. If called with a `ConnectionEndpoint`, it will call `startBotAndConnect()` under the hood.
   - Introduced `startBot()` for performing just the endpoint POST for kicking off a bot process and optionally returning connection parameters required by the transport.
-  - Introduced `startBotAndConnect()` which takes an `APIEndpoint` and calls both `startBot()` and `connect()`, passing any data returned from the `startBot()` endpoint to `connect()` as transport parameters.
+  - Introduced `startBotAndConnect()` which takes an `APIRequest` and calls both `startBot()` and `connect()`, passing any data returned from the `startBot()` endpoint to `connect()` as transport parameters.
 
 ## [1.1.0]
 

--- a/client-js/CHANGELOG.md
+++ b/client-js/CHANGELOG.md
@@ -5,6 +5,14 @@ All notable changes to **Pipecat Client JS** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Improved flexibility and clarity around `connect()`:
+  - Renamed `ConnectionEndpoint` to `APIEndpoint` for clarity.
+  - Deprecated use of `connect()` with a `ConnectionEndpoint` params type in favor of separating out the authorization step from the connection step. Uses of `connect()` with a `ConnectionEndpoint` should be updated to call `startBotAndConnect()` instead. See below.  `connect()` now performs only the portion of the logic for connecting the transport. If called with a `ConnectionEndpoint`, it will call `startBotAndConnect()` under the hood.
+  - Introduced `startBot()` for performing just the endpoint POST for kicking off a bot process and optionally returning connection parameters required by the transport.
+  - Introduced `startBotAndConnect()` which takes an `APIEndpoint` and calls both `startBot()` and `connect()`, passing any data returned from the `startBot()` endpoint to `connect()` as transport parameters.
+
 ## [1.1.0]
 
 - Added support for handling errors with the local cam/mic/speaker by introducing a new PipecatClient callback, `onDeviceError`, and RTVI event, `deviceError`.

--- a/client-js/README.md
+++ b/client-js/README.md
@@ -48,7 +48,7 @@ const pcClient = new PipecatClient({
 });
 
 try {
-  await pcClient.connect({ endpoint: "https://your-connect-end-point-here/connect" });
+  await pcClient.startBotAndConnect({ endpoint: "https://your-connect-end-point-here/connect" });
 } catch (e) {
   console.error(e.message);
 }

--- a/client-js/client/rest_helpers.ts
+++ b/client-js/client/rest_helpers.ts
@@ -10,26 +10,31 @@ type Serializable =
   | Serializable[]
   | { [key: number | string]: Serializable };
 
-export interface ConnectionEndpoint {
-  endpoint: string;
+export interface APIEndpoint {
+  endpoint: string | URL | globalThis.Request;
   headers?: Headers;
   requestData?: Serializable;
   timeout?: number;
 }
 
-export function isConnectionEndpoint(value: unknown): boolean {
+/**
+ * @deprecated Use APIEndpoint instead
+ */
+export type ConnectionEndpoint = APIEndpoint;
+
+export function isAPIEndpoint(value: unknown): boolean {
   if (
     typeof value === "object" &&
     value !== null &&
     Object.keys(value).includes("endpoint")
   ) {
-    return typeof (value as ConnectionEndpoint)["endpoint"] === "string";
+    return typeof (value as APIEndpoint)["endpoint"] === "string";
   }
   return false;
 }
 
 export async function getTransportConnectionParams(
-  cxnOpts: ConnectionEndpoint,
+  cxnOpts: APIEndpoint,
   abortController?: AbortController
 ): Promise<TransportConnectionParams> {
   if (!abortController) {

--- a/client-js/client/rest_helpers.ts
+++ b/client-js/client/rest_helpers.ts
@@ -28,7 +28,12 @@ export function isAPIEndpoint(value: unknown): boolean {
     value !== null &&
     Object.keys(value).includes("endpoint")
   ) {
-    return typeof (value as APIEndpoint)["endpoint"] === "string";
+    const endpoint = (value as APIEndpoint)["endpoint"];
+    return (
+      typeof endpoint === "string" ||
+      endpoint instanceof URL ||
+      (typeof Request !== "undefined" && endpoint instanceof Request)
+    );
   }
   return false;
 }


### PR DESCRIPTION
Deprecated use of connect() for both starting the bot and connecting, separating it out into startBot() and connect() along with a convenience method for doing both: startBotAndConnect()

Also renamed ConnectionEndpoint to a more generic and informative name of APIEndpoint