### PR TITLE
[React] Implement multi-participant handling & state

### DIFF
--- a/client-react/CHANGELOG.md
+++ b/client-react/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to **Pipecat Client React** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Multi-participant support**: Full support for handling multiple participants in sessions
+  - New `usePipecatClientParticipant()` hook to access individual participant data
+  - New `usePipecatClientParticipantIds()` hook to get all participant IDs with filtering options
+  - Support for both regular and screen share media tracks per participant
+
+### Changed
+
+- `PipecatClientVideo` component now requires `participantId` prop when `participant` is set to `"remote"`
+- Enhanced `PipecatClientAudio` component now renders audio for all participants automatically
+- Enhanced `PipecatClientVideo` component now supports remote participants
+- `usePipecatClientMediaTrack()` hook signature updated to support remote participants
+
 ## [1.0.1]
 
 - Fixed state synchronization between different instances of `usePipecatClientCamControl()`, `usePipecatClientMicControl()` and `usePipecatClientTransportState()` ([#125](https://github.com/pipecat-ai/pipecat-client-web/pull/125))

--- a/client-react/src/PipecatClientParticipantManager.tsx
+++ b/client-react/src/PipecatClientParticipantManager.tsx
@@ -1,0 +1,203 @@
+/**
+ * Copyright (c) 2025, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { Participant, RTVIEvent, Tracks } from "@pipecat-ai/client-js";
+import { atom } from "jotai";
+import { atomFamily, useAtomCallback } from "jotai/utils";
+import { memo, useCallback } from "react";
+
+import { useRTVIClientEvent } from "./useRTVIClientEvent";
+
+// Remote participants tracking
+export const remoteParticipantIdsAtom = atom<string[]>([]);
+
+// Bot ID mapping - maps the bot's UUID to our internal "bot" identifier
+const botIdAtom = atom<string | null>(null);
+
+const localParticipantAtom = atom<Participant | null>(null);
+const botParticipantAtom = atom<Participant | null>(null);
+
+export const participantAtom = atomFamily((participantId: string) =>
+  atom<Participant | null>((get) => {
+    // Handle special cases for local and bot participants
+    if (participantId === "local") {
+      return get(localParticipantAtom);
+    }
+
+    if (participantId === "bot") {
+      return get(botParticipantAtom);
+    }
+
+    // For remote participants, return the stored value
+    return get(remoteParticipantAtom(participantId));
+  })
+);
+
+// Keep the original remoteParticipantAtom for internal use
+const remoteParticipantAtom = atomFamily(() => atom<Participant | null>(null));
+
+// Unified track atom family for all participants and track types
+type TrackType = keyof Tracks["local"];
+type TrackKey = `${string}:${TrackType}`;
+
+export const trackAtom = atomFamily((key: TrackKey) => {
+  // Create a unique atom for each participant/track combination
+  // Key format: "participantId:trackType"
+  void key; // Acknowledge the key parameter
+  return atom<MediaStreamTrack | null>(null);
+});
+
+/**
+ * Component that manages participant events globally.
+ */
+export const PipecatClientParticipantManager = memo(() => {
+  const addParticipant = useAtomCallback(
+    useCallback((get, set, participant: Participant) => {
+      if (participant.local) {
+        set(localParticipantAtom, participant);
+        return;
+      }
+
+      if (participant.id === get(botIdAtom)) {
+        set(botParticipantAtom, participant);
+        return;
+      }
+
+      const currentIds = get(remoteParticipantIdsAtom);
+      if (!currentIds.includes(participant.id)) {
+        set(remoteParticipantIdsAtom, [...currentIds, participant.id]);
+      }
+      set(remoteParticipantAtom(participant.id), participant);
+    }, [])
+  );
+
+  const removeParticipant = useAtomCallback(
+    useCallback((get, set, participant: Participant) => {
+      if (participant.local) {
+        set(localParticipantAtom, null);
+        return;
+      }
+
+      if (participant.id === get(botIdAtom)) {
+        set(botParticipantAtom, null);
+        return;
+      }
+
+      const currentIds = get(remoteParticipantIdsAtom);
+      set(
+        remoteParticipantIdsAtom,
+        currentIds.filter((id) => id !== participant.id)
+      );
+
+      // Clean up participant data
+      set(remoteParticipantAtom(participant.id), null);
+
+      // Clean up all track types for this participant
+      const trackTypes: TrackType[] = [
+        "audio",
+        "video",
+        "screenAudio",
+        "screenVideo",
+      ];
+      trackTypes.forEach((trackType) => {
+        const atom = trackAtom(`${participant.id}:${trackType}`);
+        set(atom, null);
+      });
+    }, [])
+  );
+
+  // Set up event listeners for participant events
+  useRTVIClientEvent(
+    RTVIEvent.ParticipantConnected,
+    useCallback(
+      (participant: Participant) => {
+        addParticipant(participant);
+      },
+      [addParticipant]
+    )
+  );
+
+  useRTVIClientEvent(
+    RTVIEvent.ParticipantLeft,
+    useCallback(
+      (participant: Participant) => {
+        removeParticipant(participant);
+      },
+      [removeParticipant]
+    )
+  );
+
+  // Handle bot connection to map bot UUID to our internal "bot" identifier
+  useRTVIClientEvent(
+    RTVIEvent.BotConnected,
+    useAtomCallback(
+      useCallback((_get, set, participant: Participant) => {
+        set(botIdAtom, participant.id);
+      }, [])
+    )
+  );
+
+  // Set up event listeners for media track events
+  const handleTrackStarted = useAtomCallback(
+    useCallback(
+      (get, set, track: MediaStreamTrack, participant?: Participant) => {
+        if (!participant) return;
+
+        const trackType = track.kind as TrackType;
+        // Map participant to our internal ID system
+        let internalId: string;
+        if (participant.local) {
+          internalId = "local";
+        } else {
+          // Check if this is the bot by comparing with stored bot ID
+          const botId = get(botIdAtom);
+          internalId =
+            botId && participant.id === botId ? "bot" : participant.id;
+        }
+        // Update track directly
+        const atom = trackAtom(`${internalId}:${trackType}`);
+        const oldTrack = get(atom);
+        if (oldTrack?.id === track.id) return;
+        set(atom, track);
+      },
+      []
+    )
+  );
+
+  const handleScreenTrackStarted = useAtomCallback(
+    useCallback(
+      (get, set, track: MediaStreamTrack, participant?: Participant) => {
+        if (!participant) return;
+
+        const trackType =
+          track.kind === "audio" ? "screenAudio" : "screenVideo";
+        // Map participant to our internal ID system
+        let internalId: string;
+        if (participant.local) {
+          internalId = "local";
+        } else {
+          // Check if this is the bot by comparing with stored bot ID
+          const botId = get(botIdAtom);
+          internalId =
+            botId && participant.id === botId ? "bot" : participant.id;
+        }
+        // Update track directly
+        const atom = trackAtom(`${internalId}:${trackType}`);
+        const oldTrack = get(atom);
+        if (oldTrack?.id === track.id) return;
+        set(atom, track);
+      },
+      []
+    )
+  );
+
+  useRTVIClientEvent(RTVIEvent.TrackStarted, handleTrackStarted);
+  useRTVIClientEvent(RTVIEvent.ScreenTrackStarted, handleScreenTrackStarted);
+
+  return null;
+});
+
+PipecatClientParticipantManager.displayName = "PipecatClientParticipantManager";

--- a/client-react/src/PipecatClientProvider.tsx
+++ b/client-react/src/PipecatClientProvider.tsx
@@ -18,6 +18,7 @@ import {
   name as packageName,
   version as packageVersion,
 } from "../package.json";
+import { PipecatClientParticipantManager } from "./PipecatClientParticipantManager";
 import { PipecatClientStateProvider } from "./PipecatClientState";
 import { RTVIEventContext } from "./RTVIEventContext";
 
@@ -116,7 +117,10 @@ export const PipecatClientProvider: React.FC<
     <JotaiProvider store={jotaiStore}>
       <PipecatClientContext.Provider value={{ client }}>
         <RTVIEventContext.Provider value={{ on, off }}>
-          <PipecatClientStateProvider>{children}</PipecatClientStateProvider>
+          <PipecatClientStateProvider>
+            {children}
+            <PipecatClientParticipantManager />
+          </PipecatClientStateProvider>
         </RTVIEventContext.Provider>
       </PipecatClientContext.Provider>
     </JotaiProvider>

--- a/client-react/src/PipecatClientVideo.tsx
+++ b/client-react/src/PipecatClientVideo.tsx
@@ -15,9 +15,12 @@ interface PipecatClientVideoInterface {
   width: number;
 }
 
-export interface Props
-  extends Omit<React.VideoHTMLAttributes<HTMLVideoElement>, "onResize"> {
-  participant: "local" | "bot";
+type BaseProps = Omit<
+  React.VideoHTMLAttributes<HTMLVideoElement>,
+  "onResize"
+> & {
+  participant: "local" | "bot" | "remote";
+  participantId?: string;
 
   /**
    * Defines the video track type to display. Default: 'video'.
@@ -38,12 +41,22 @@ export interface Props
    * Returns the video's native width, height and aspectRatio.
    */
   onResize?(dimensions: PipecatClientVideoInterface): void;
-}
+};
 
+export type Props = BaseProps extends { participant: infer P }
+  ? P extends "remote"
+    ? BaseProps & { participantId: string }
+    : BaseProps
+  : BaseProps;
+
+/**
+ * Component that renders a video track
+ */
 export const PipecatClientVideo = forwardRef<HTMLVideoElement, Props>(
   function VoiceClientVideo(
     {
       participant = "local",
+      participantId,
       fit = "contain",
       mirror,
       onResize,
@@ -55,7 +68,8 @@ export const PipecatClientVideo = forwardRef<HTMLVideoElement, Props>(
   ) {
     const videoTrack: MediaStreamTrack | null = usePipecatClientMediaTrack(
       trackType,
-      participant
+      participant,
+      participantId
     );
 
     const videoEl = useRef<HTMLVideoElement>(null);

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -14,6 +14,8 @@ import { usePipecatClientCamControl } from "./usePipecatClientCamControl";
 import { usePipecatClientMediaDevices } from "./usePipecatClientMediaDevices";
 import { usePipecatClientMediaTrack } from "./usePipecatClientMediaTrack";
 import { usePipecatClientMicControl } from "./usePipecatClientMicControl";
+import { usePipecatClientParticipant } from "./usePipecatClientParticipant";
+import { usePipecatClientParticipantIds } from "./usePipecatClientParticipantIds";
 import { usePipecatClientTransportState } from "./usePipecatClientTransportState";
 import { useRTVIClientEvent } from "./useRTVIClientEvent";
 import { VoiceVisualizer } from "./VoiceVisualizer";
@@ -29,6 +31,8 @@ export {
   usePipecatClientMediaDevices,
   usePipecatClientMediaTrack,
   usePipecatClientMicControl,
+  usePipecatClientParticipant,
+  usePipecatClientParticipantIds,
   usePipecatClientTransportState,
   useRTVIClientEvent,
   VoiceVisualizer,

--- a/client-react/src/usePipecatClientParticipant.ts
+++ b/client-react/src/usePipecatClientParticipant.ts
@@ -1,0 +1,16 @@
+/**
+ * Copyright (c) 2025, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { useAtomValue } from "jotai";
+
+import { participantAtom } from "./PipecatClientParticipantManager";
+
+/**
+ * Hook to get individual participant data
+ */
+export const usePipecatClientParticipant = (participantId: string) => {
+  return useAtomValue(participantAtom(participantId));
+};

--- a/client-react/src/usePipecatClientParticipantIds.ts
+++ b/client-react/src/usePipecatClientParticipantIds.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2025, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { useAtomValue } from "jotai";
+
+import { remoteParticipantIdsAtom } from "./PipecatClientParticipantManager";
+
+/**
+ * Hook to get all participant IDs
+ */
+export const usePipecatClientParticipantIds = (
+  includeLocal = true,
+  includeBot = true
+) => {
+  const remoteParticipantIds = useAtomValue(remoteParticipantIdsAtom);
+
+  return {
+    participantIds: [
+      ...(includeLocal ? ["local"] : []),
+      ...(includeBot ? ["bot"] : []),
+      ...remoteParticipantIds,
+    ],
+    remoteParticipantIds,
+  };
+};


### PR DESCRIPTION
This PR implements handling for multi-participant sessions. The local participant and bot are still referenced via `"local"` and `"bot"`. Remote participants are returned through the `usePipecatClientParticipantIds` hook (can include "local" and "bot", too). We keep track of the bot's participant id to correctly distinguish between bot and remote participant tracks.

I have already outlined the changes in the changelog:

### Added

- **Multi-participant support**: Full support for handling multiple participants in sessions
  - New `usePipecatClientParticipant()` hook to access individual participant data
  - New `usePipecatClientParticipantIds()` hook to get all participant IDs with filtering options
  - Support for both regular and screen share media tracks per participant

### Changed

- `PipecatClientVideo` component now requires `participantId` prop when `participant` is set to `"remote"`
- Enhanced `PipecatClientAudio` component now renders audio for all participants automatically
- Enhanced `PipecatClientVideo` component now supports remote participants
- `usePipecatClientMediaTrack()` hook signature updated to support remote participants