### PR TITLE
Deprecate appendToContext in lieu of more-specific sendText with adde…

### DIFF
--- a/client-js/CHANGELOG.md
+++ b/client-js/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to **Pipecat Client JS** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Added new `sendText()` method to support the new RTVI `send-text` event. The method takes a string, along with an optional set of options to control whether the bot should respond immediately and/or whether the bot should respond with audio (vs. text only). Note: This is a replacement for the current `appendToContext()` method and changes the default of `run_immediately` to `True`.
+
+### Deprecated
+
+- Deprecated `appendToContext()` in lieu of the new `sendText()` method. This sets a standard for future methods like `sendImage()`.
+
 ## [1.3.0]
 
 ### Added

--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -24,6 +24,8 @@ export enum RTVIMessageType {
   DISCONNECT_BOT = "disconnect-bot",
   // Client-to-server messages
   CLIENT_MESSAGE = "client-message",
+  SEND_TEXT = "send-text",
+  // DEPRECATED
   APPEND_TO_CONTEXT = "append-to-context",
 
   /**
@@ -167,12 +169,19 @@ export type LLMFunctionCallResultResponse = {
   result: LLMFunctionCallResult;
 };
 
+export type SendTextOptions = {
+  run_immediately?: boolean;
+  audio_response?: boolean;
+};
+
+/** DEPRECATED */
 export type LLMContextMessage = {
   role: "user" | "assistant";
   content: unknown;
   run_immediately?: boolean;
 };
 
+/** DEPRECATED */
 export type AppendToContextResultData = {
   result: Record<string, unknown> | string;
 };


### PR DESCRIPTION
…d support for specifying if the bot should respond with audio or not. Resolves #147 (or most of it).

This also fixes an issue with the now-deprecated appendToContext() method which would never resolve, because Pipecat does not send a response. 

This couples with https://github.com/pipecat-ai/pipecat/pull/2683