### PR TITLE
[React] Implement screenshare hook & component

### DIFF
--- a/client-react/CHANGELOG.md
+++ b/client-react/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to **Pipecat Client React** will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0]
+
+- Added new hook `usePipecatClientScreenShareControl()`
+- Added new headless component `PipecatClientScreenShareToggle`
+
 ## [1.0.1]
 
 - Fixed state synchronization between different instances of `usePipecatClientCamControl()`, `usePipecatClientMicControl()` and `usePipecatClientTransportState()` ([#125](https://github.com/pipecat-ai/pipecat-client-web/pull/125))

--- a/client-react/src/PipecatClientScreenShareToggle.tsx
+++ b/client-react/src/PipecatClientScreenShareToggle.tsx
@@ -1,0 +1,63 @@
+/**
+ * Copyright (c) 2025, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import React, { useCallback, useEffect } from "react";
+
+import { usePipecatClientScreenShareControl } from "./usePipecatClientScreenShareControl";
+
+export interface PipecatClientScreenShareToggleProps {
+  /**
+   * Callback when screen share state changes
+   */
+  onScreenShareEnabledChanged?: (enabled: boolean) => void;
+
+  /**
+   * Optional prop to disable the screen share toggle.
+   * When disabled, changes are not applied to the client.
+   * @default false
+   */
+  disabled?: boolean;
+
+  /**
+   * Render prop that provides state and handlers to the children
+   */
+  children: (props: {
+    disabled?: boolean;
+    isScreenShareEnabled: boolean;
+    onClick: () => void;
+  }) => React.ReactNode;
+}
+
+/**
+ * Headless component for controlling screen share state
+ */
+export const PipecatClientScreenShareToggle: React.FC<
+  PipecatClientScreenShareToggleProps
+> = ({ onScreenShareEnabledChanged, disabled = false, children }) => {
+  const { enableScreenShare, isScreenShareEnabled } =
+    usePipecatClientScreenShareControl();
+
+  const handleToggleScreenShare = useCallback(() => {
+    if (disabled) return;
+    enableScreenShare(!isScreenShareEnabled);
+  }, [disabled, enableScreenShare, isScreenShareEnabled]);
+
+  useEffect(() => {
+    onScreenShareEnabledChanged?.(isScreenShareEnabled);
+  }, [isScreenShareEnabled, onScreenShareEnabledChanged]);
+
+  return (
+    <>
+      {children({
+        isScreenShareEnabled,
+        onClick: handleToggleScreenShare,
+        disabled,
+      })}
+    </>
+  );
+};
+
+export default PipecatClientScreenShareToggle;

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -8,12 +8,14 @@ import { PipecatClientAudio } from "./PipecatClientAudio";
 import { PipecatClientCamToggle } from "./PipecatClientCamToggle";
 import { PipecatClientMicToggle } from "./PipecatClientMicToggle";
 import { PipecatClientProvider } from "./PipecatClientProvider";
+import { PipecatClientScreenShareToggle } from "./PipecatClientScreenShareToggle";
 import { PipecatClientVideo } from "./PipecatClientVideo";
 import { usePipecatClient } from "./usePipecatClient";
 import { usePipecatClientCamControl } from "./usePipecatClientCamControl";
 import { usePipecatClientMediaDevices } from "./usePipecatClientMediaDevices";
 import { usePipecatClientMediaTrack } from "./usePipecatClientMediaTrack";
 import { usePipecatClientMicControl } from "./usePipecatClientMicControl";
+import { usePipecatClientScreenShareControl } from "./usePipecatClientScreenShareControl";
 import { usePipecatClientTransportState } from "./usePipecatClientTransportState";
 import { useRTVIClientEvent } from "./useRTVIClientEvent";
 import { VoiceVisualizer } from "./VoiceVisualizer";
@@ -23,12 +25,14 @@ export {
   PipecatClientCamToggle,
   PipecatClientMicToggle,
   PipecatClientProvider,
+  PipecatClientScreenShareToggle,
   PipecatClientVideo,
   usePipecatClient,
   usePipecatClientCamControl,
   usePipecatClientMediaDevices,
   usePipecatClientMediaTrack,
   usePipecatClientMicControl,
+  usePipecatClientScreenShareControl,
   usePipecatClientTransportState,
   useRTVIClientEvent,
   VoiceVisualizer,

--- a/client-react/src/usePipecatClientScreenShareControl.ts
+++ b/client-react/src/usePipecatClientScreenShareControl.ts
@@ -1,0 +1,17 @@
+/**
+ * Copyright (c) 2025, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { useContext } from "react";
+
+import { PipecatClientScreenShareStateContext } from "./PipecatClientState";
+
+/**
+ * Hook to control screen share state using React Context
+ * This provides a simpler interface for basic screen share control
+ * For more advanced state management with Jotai atoms, use usePipecatClientScreenShare
+ */
+export const usePipecatClientScreenShareControl = () =>
+  useContext(PipecatClientScreenShareStateContext);


### PR DESCRIPTION
This PR adds a new hook `usePipecatClientScreenShareControl()` and a new headless component `PipecatClientScreenShareToggle` in order to provide stateful representations of a local user's screen share state.