### PR TITLE
fix(react): backdate injected messages during active bot response

### DIFF
--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -356,15 +356,35 @@ export function injectMessage(
   }
 ) {
   const now = new Date();
+  const current = get(messagesAtom);
+
+  // If the most recent message is an active (non-final) assistant message,
+  // backdate the injected message so it sorts before the assistant's createdAt.
+  // This prevents the injected message from splitting the bot's response across
+  // two bubbles and breaking the karaoke cursor.
+  const lastMessage = current[current.length - 1];
+  const lastAssistant =
+    lastMessage?.role === "assistant" ? lastMessage : undefined;
+  let timestamp: string;
+  if (
+    lastAssistant &&
+    lastAssistant.final === false &&
+    messageData.role === "system"
+  ) {
+    const assistantTime = new Date(lastAssistant.createdAt);
+    timestamp = new Date(assistantTime.getTime() - 1).toISOString();
+  } else {
+    timestamp = now.toISOString();
+  }
+
   const message: ConversationMessage = {
     role: messageData.role,
     final: true,
     parts: [...messageData.parts],
-    createdAt: now.toISOString(),
+    createdAt: timestamp,
     updatedAt: now.toISOString(),
   };
 
-  const current = get(messagesAtom);
   const updatedMessages = [...current, message];
   const processedMessages = normalizeMessagesForUI(updatedMessages);
 

--- a/client-react/tests/conversation/helpers/storeHarness.ts
+++ b/client-react/tests/conversation/helpers/storeHarness.ts
@@ -9,7 +9,10 @@ import {
   botOutputMessageStateAtom,
   messagesAtom,
 } from "@/conversation/conversationAtoms";
-import type { ConversationMessage } from "@/conversation/types";
+import type {
+  ConversationMessage,
+  ConversationMessagePart,
+} from "@/conversation/types";
 
 /**
  * Store-level test harness that replicates the ConversationProvider's
@@ -287,6 +290,13 @@ export function createStoreHarness() {
     actions.unregisterMessageCallback(store.get, store.set, id);
   }
 
+  function injectMessage(messageData: {
+    role: "user" | "assistant" | "system";
+    parts: ConversationMessagePart[];
+  }) {
+    actions.injectMessage(store.get, store.set, messageData);
+  }
+
   return {
     reset,
     ensureAssistantMessage,
@@ -311,6 +321,7 @@ export function createStoreHarness() {
     updateFunctionCall,
     updateLastStartedFunctionCall,
     updateAssistantBotOutput,
+    injectMessage,
     registerMessageCallback,
     unregisterMessageCallback,
   };

--- a/client-react/tests/conversation/stores/conversationStore.test.ts
+++ b/client-react/tests/conversation/stores/conversationStore.test.ts
@@ -488,6 +488,101 @@ describe("conversationStore", () => {
     });
   });
 
+  // -----------------------------------------------------------------------
+  // injectMessage -- backdating during active assistant message
+  // -----------------------------------------------------------------------
+  describe("injectMessage (backdating)", () => {
+    const T0 = "2024-01-01T00:00:00.000Z";
+
+    it("backdates injected message before active assistant message", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [{ text: "Hello", final: false, createdAt: T0 }],
+      });
+      const assistantCreatedAt = harness.getMessages()[0].createdAt;
+
+      harness.injectMessage({
+        role: "system",
+        parts: [{ text: "System info", final: true, createdAt: T0 }],
+      });
+
+      const messages = harness.getMessages();
+      expect(messages).toHaveLength(2);
+      // System message should sort before the assistant message
+      expect(messages[0].role).toBe("system");
+      expect(messages[1].role).toBe("assistant");
+      expect(messages[0].createdAt < assistantCreatedAt).toBe(true);
+    });
+
+    it("does not backdate when assistant message is final", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [{ text: "Hello", final: false, createdAt: T0 }],
+      });
+      harness.finalizeAssistant();
+
+      harness.injectMessage({
+        role: "system",
+        parts: [{ text: "System info", final: true, createdAt: T0 }],
+      });
+
+      const messages = harness.getMessages();
+      // System message should sort after the finalized assistant message
+      expect(messages[0].role).toBe("assistant");
+      expect(messages[1].role).toBe("system");
+    });
+
+    it("does not backdate when no assistant message exists", () => {
+      harness.injectMessage({
+        role: "system",
+        parts: [{ text: "System info", final: true, createdAt: T0 }],
+      });
+
+      const messages = harness.getMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].role).toBe("system");
+    });
+
+    it("does not backdate injected user messages", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [{ text: "Hello", final: false, createdAt: T0 }],
+      });
+
+      harness.injectMessage({
+        role: "user",
+        parts: [{ text: "Hi there", final: true, createdAt: T0 }],
+      });
+
+      const messages = harness.getMessages();
+      // User message should sort after the assistant (not backdated)
+      expect(messages[messages.length - 1].role).toBe("user");
+    });
+
+    it("does not backdate when non-final assistant is not the last message", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [{ text: "Hello", final: false, createdAt: T0 }],
+      });
+      // User message comes after the assistant
+      harness.emitUserTranscript("Hey", true);
+      harness.finalizeUser();
+
+      harness.injectMessage({
+        role: "system",
+        parts: [{ text: "System info", final: true, createdAt: T0 }],
+      });
+
+      const messages = harness.getMessages();
+      // System message should be last, not backdated before the user message
+      expect(messages[messages.length - 1].role).toBe("system");
+    });
+  });
+
   describe("filterEmptyMessages", () => {
     it("removes empty messages that have a later non-empty message with same role", () => {
       const messages: ConversationMessage[] = [


### PR DESCRIPTION
## Summary
- Injected messages (e.g. system messages arriving mid-response) could insert chronologically between existing and incoming bot text, splitting the response across two bubbles and breaking the karaoke cursor
- `injectMessage` now detects an active (non-final) assistant message and backdates the injected message's timestamp by 1ms before the assistant's `createdAt`, ensuring it always sorts above the active response

## Test plan
- [x] Added tests: backdating during active assistant, no backdating when finalized, no backdating when no assistant exists
- [x] All 149 tests pass
- [ ] Manual verification with injected system messages during bot speech