### PR TITLE
fix(react): backdate mid-turn function calls to preserve karaoke cursor

### DIFF
--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -653,11 +653,28 @@ export function addFunctionCall(
   }
 
   const now = new Date();
+
+  // If the most recent message is an active (non-final) assistant message,
+  // backdate the function call so it sorts before the assistant's createdAt.
+  // This prevents the function call from splitting the bot's response across
+  // two bubbles and breaking the karaoke cursor.
+  const lastMessage = messages[messages.length - 1];
+  let timestamp: string;
+  if (
+    lastMessage?.role === "assistant" &&
+    lastMessage.final === false
+  ) {
+    const assistantTime = new Date(lastMessage.createdAt);
+    timestamp = new Date(assistantTime.getTime() - 1).toISOString();
+  } else {
+    timestamp = now.toISOString();
+  }
+
   const message: ConversationMessage = {
     role: "function_call",
     final: false,
     parts: [],
-    createdAt: now.toISOString(),
+    createdAt: timestamp,
     updatedAt: now.toISOString(),
     functionCall: {
       function_name: data.function_name,
@@ -765,7 +782,7 @@ export function handleFunctionCallStarted(
   if (
     lastFc?.functionCall &&
     lastFc.functionCall.status !== "started" &&
-    Date.now() - new Date(lastFc.createdAt).getTime() < 2000
+    Date.now() - new Date(lastFc.updatedAt ?? lastFc.createdAt).getTime() < 2000
   ) {
     if (
       data.function_name &&

--- a/client-react/tests/conversation/integration/functionCallLifecycle.test.ts
+++ b/client-react/tests/conversation/integration/functionCallLifecycle.test.ts
@@ -249,6 +249,32 @@ describe("function call lifecycle - integration", () => {
       expect(fcMessages).toHaveLength(2);
     });
 
+    it("Started after backdated InProgress does not create duplicate", () => {
+      // Active assistant message causes function call to be backdated
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [
+          { text: "Let me look that up", final: false, createdAt: "2024-01-01T00:00:00.000Z" },
+        ],
+      });
+
+      // InProgress arrives first (out-of-order), gets backdated
+      harness.handleFunctionCallInProgress({
+        function_name: "search",
+        tool_call_id: "call_1",
+        args: { q: "test" },
+      });
+
+      // Started arrives — should still detect the duplicate via updatedAt
+      harness.handleFunctionCallStarted({ function_name: "search" });
+
+      const messages = harness.getMessages();
+      const fcMessages = messages.filter((m) => m.role === "function_call");
+      expect(fcMessages).toHaveLength(1);
+      expect(fcMessages[0].functionCall!.status).toBe("in_progress");
+    });
+
     it("Started fills in missing function_name on existing entry", () => {
       // InProgress arrives first WITHOUT function_name
       harness.handleFunctionCallInProgress({

--- a/client-react/tests/conversation/stores/functionCalls.test.ts
+++ b/client-react/tests/conversation/stores/functionCalls.test.ts
@@ -86,6 +86,61 @@ describe("conversationStore - function calls", () => {
 
       expect(harness.getMessages()).toHaveLength(2);
     });
+
+    it("backdates function call before active assistant message", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [
+          { text: "Let me check", final: false, createdAt: "2024-01-01T00:00:00.000Z" },
+        ],
+      });
+      const assistantCreatedAt = harness.getMessages()[0].createdAt;
+
+      harness.addFunctionCall({ function_name: "get_weather" });
+
+      const messages = harness.getMessages();
+      expect(messages).toHaveLength(2);
+      // Function call should sort before the assistant message
+      expect(messages[0].role).toBe("function_call");
+      expect(messages[1].role).toBe("assistant");
+      expect(messages[0].createdAt < assistantCreatedAt).toBe(true);
+    });
+
+    it("does not backdate when assistant message is final", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [
+          { text: "Done", final: false, createdAt: "2024-01-01T00:00:00.000Z" },
+        ],
+      });
+      harness.finalizeAssistant();
+
+      harness.addFunctionCall({ function_name: "get_weather" });
+
+      const messages = harness.getMessages();
+      expect(messages[0].role).toBe("assistant");
+      expect(messages[1].role).toBe("function_call");
+    });
+
+    it("does not backdate when assistant is not the last message", () => {
+      harness.addMessage({
+        role: "assistant",
+        final: false,
+        parts: [
+          { text: "Hello", final: false, createdAt: "2024-01-01T00:00:00.000Z" },
+        ],
+      });
+      harness.emitUserTranscript("Hey", true);
+      harness.finalizeUser();
+
+      harness.addFunctionCall({ function_name: "get_weather" });
+
+      const messages = harness.getMessages();
+      // Function call should be last, not backdated
+      expect(messages[messages.length - 1].role).toBe("function_call");
+    });
   });
 
   // -----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- When the LLM calls a function mid-turn, the function call message inserts chronologically after the active assistant message, causing subsequent spoken botOutput to create a new message instead of advancing the existing karaoke cursor
- `addFunctionCall` now backdates its timestamp before the active assistant message (same approach as #193 for injected messages), keeping the assistant response as the last message so the cursor continues uninterrupted

## Test plan
- [x] Added tests: backdating during active assistant, no backdating when finalized, no backdating when assistant isn't last
- [x] All 161 tests pass
- [ ] Manual verification with a bot that calls functions mid-response