### PR TITLE
ci: exclude merge commits from release-please changelogs

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "include-component-in-tag": true,
   "separate-pull-requests": true,
+  "exclude-merges": true,
   "packages": {
     "client-js": {
       "component": "client-js",


### PR DESCRIPTION
## Summary
- Adds `exclude-merges: true` to release-please config to prevent duplicate changelog entries for single-commit PRs (where both the commit and its merge commit were being included)