### PR TITLE
feat(react): add botOutputFilter option to usePipecatConversation

### DIFF
--- a/client-react/src/conversation/filterBotOutputText.ts
+++ b/client-react/src/conversation/filterBotOutputText.ts
@@ -1,0 +1,22 @@
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import type { BotOutputFilter, BotOutputText } from "./types";
+
+/**
+ * Apply a {@link BotOutputFilter} to a {@link BotOutputText}, zeroing out any
+ * portion whose flag is explicitly `false`. Both flags default to `true`, so
+ * an omitted filter (or `undefined`) returns the text unchanged.
+ */
+export function filterBotOutputText(
+  text: BotOutputText,
+  filter?: BotOutputFilter
+): BotOutputText {
+  return {
+    spoken: filter?.spoken === false ? "" : text.spoken,
+    unspoken: filter?.unspoken === false ? "" : text.unspoken,
+  };
+}

--- a/client-react/src/conversation/types.ts
+++ b/client-react/src/conversation/types.ts
@@ -24,6 +24,18 @@ export interface BotOutputText {
 }
 
 /**
+ * Filter controlling which portions of BotOutput text are returned by the hook.
+ * The underlying atoms always store the full data; this filter controls what
+ * the consumer receives.
+ */
+export interface BotOutputFilter {
+  /** Include spoken text (TTS-confirmed portion). Default: true */
+  spoken?: boolean;
+  /** Include unspoken text (LLM output not yet spoken). Default: true */
+  unspoken?: boolean;
+}
+
+/**
  * Metadata for aggregation types to control rendering and speech progress behavior
  */
 export interface AggregationMetadata {

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -11,6 +11,7 @@ import {
   mergeMessages,
   sortByCreatedAt,
 } from "./conversation/conversationActions";
+import { filterBotOutputText } from "./conversation/filterBotOutputText";
 import { useConversationContext } from "./conversation/PipecatConversationProvider";
 import { PipecatClientAudio } from "./PipecatClientAudio";
 import { PipecatClientCamToggle } from "./PipecatClientCamToggle";
@@ -31,6 +32,7 @@ import { VoiceVisualizer } from "./VoiceVisualizer";
 
 export {
   deduplicateFunctionCalls,
+  filterBotOutputText,
   filterEmptyMessages,
   isMessageEmpty,
   mergeMessages,

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -4,6 +4,14 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
+import {
+  deduplicateFunctionCalls,
+  filterEmptyMessages,
+  isMessageEmpty,
+  mergeMessages,
+  sortByCreatedAt,
+} from "./conversation/conversationActions";
+import { useConversationContext } from "./conversation/PipecatConversationProvider";
 import { PipecatClientAudio } from "./PipecatClientAudio";
 import { PipecatClientCamToggle } from "./PipecatClientCamToggle";
 import { PipecatClientMicToggle } from "./PipecatClientMicToggle";
@@ -17,25 +25,24 @@ import { usePipecatClientMediaTrack } from "./usePipecatClientMediaTrack";
 import { usePipecatClientMicControl } from "./usePipecatClientMicControl";
 import { usePipecatClientScreenShareControl } from "./usePipecatClientScreenShareControl";
 import { usePipecatClientTransportState } from "./usePipecatClientTransportState";
+import { usePipecatConversation } from "./usePipecatConversation";
 import { useRTVIClientEvent } from "./useRTVIClientEvent";
 import { VoiceVisualizer } from "./VoiceVisualizer";
-import {
+
+export {
   deduplicateFunctionCalls,
   filterEmptyMessages,
   isMessageEmpty,
   mergeMessages,
-  sortByCreatedAt,
-} from "./conversation/conversationActions";
-import { useConversationContext } from "./conversation/PipecatConversationProvider";
-import { usePipecatConversation } from "./usePipecatConversation";
-
-export {
   PipecatClientAudio,
   PipecatClientCamToggle,
   PipecatClientMicToggle,
   PipecatClientProvider,
   PipecatClientScreenShareToggle,
   PipecatClientVideo,
+  sortByCreatedAt,
+  // Conversation
+  useConversationContext,
   usePipecatClient,
   usePipecatClientCamControl,
   usePipecatClientMediaDevices,
@@ -43,21 +50,15 @@ export {
   usePipecatClientMicControl,
   usePipecatClientScreenShareControl,
   usePipecatClientTransportState,
+  usePipecatConversation,
   useRTVIClientEvent,
   VoiceVisualizer,
-  // Conversation
-  useConversationContext,
-  usePipecatConversation,
-  deduplicateFunctionCalls,
-  filterEmptyMessages,
-  isMessageEmpty,
-  mergeMessages,
-  sortByCreatedAt,
 };
 
 // Conversation types
 export type {
   AggregationMetadata,
+  BotOutputFilter,
   BotOutputText,
   ConversationMessage,
   ConversationMessagePart,

--- a/client-react/src/usePipecatConversation.ts
+++ b/client-react/src/usePipecatConversation.ts
@@ -16,6 +16,7 @@ import {
   botOutputMessageStateAtom,
   messagesAtom,
 } from "./conversation/conversationAtoms";
+import { filterBotOutputText } from "./conversation/filterBotOutputText";
 import { useConversationContext } from "./conversation/PipecatConversationProvider";
 import type {
   AggregationMetadata,
@@ -172,14 +173,14 @@ export const usePipecatConversation = ({
                 ? part.text.trim()
                 : part.text;
             if (!isSpoken) {
-              // Non-spoken aggregation types follow the unspoken filter
-              const includeUnspoken = botOutputFilter?.unspoken !== false;
+              // Non-spoken aggregation types: all content is "unspoken".
               return {
                 ...part,
                 displayMode,
-                text: includeUnspoken
-                  ? { spoken: "", unspoken: partText }
-                  : { spoken: "", unspoken: "" },
+                text: filterBotOutputText(
+                  { spoken: "", unspoken: partText },
+                  botOutputFilter
+                ),
               };
             }
 
@@ -198,16 +199,13 @@ export const usePipecatConversation = ({
                 ? ""
                 : partText;
 
-            // Apply filter
-            const filteredSpoken =
-              botOutputFilter?.spoken !== false ? spokenText : "";
-            const filteredUnspoken =
-              botOutputFilter?.unspoken !== false ? unspokenText : "";
-
             return {
               ...part,
               displayMode,
-              text: { spoken: filteredSpoken, unspoken: filteredUnspoken },
+              text: filterBotOutputText(
+                { spoken: spokenText, unspoken: unspokenText },
+                botOutputFilter
+              ),
             };
           }
         );

--- a/client-react/src/usePipecatConversation.ts
+++ b/client-react/src/usePipecatConversation.ts
@@ -19,6 +19,7 @@ import {
 import { useConversationContext } from "./conversation/PipecatConversationProvider";
 import type {
   AggregationMetadata,
+  BotOutputFilter,
   ConversationMessage,
   ConversationMessagePart,
 } from "./conversation/types";
@@ -47,6 +48,12 @@ interface Props {
    * Used to determine which aggregations should be excluded from position-based splitting.
    */
   aggregationMetadata?: Record<string, AggregationMetadata>;
+  /**
+   * Filter controlling which portions of BotOutput text are returned.
+   * The underlying atoms always store the full data; this filter controls
+   * what the consumer receives in the `messages` array.
+   */
+  botOutputFilter?: BotOutputFilter;
 }
 
 /**
@@ -72,6 +79,7 @@ export const usePipecatConversation = ({
   onMessageUpdated,
   onMessageAdded,
   aggregationMetadata,
+  botOutputFilter,
 }: Props = {}) => {
   const { injectMessage } = useConversationContext();
 
@@ -164,10 +172,14 @@ export const usePipecatConversation = ({
                 ? part.text.trim()
                 : part.text;
             if (!isSpoken) {
+              // Non-spoken aggregation types follow the unspoken filter
+              const includeUnspoken = botOutputFilter?.unspoken !== false;
               return {
                 ...part,
                 displayMode,
-                text: { spoken: "", unspoken: partText },
+                text: includeUnspoken
+                  ? { spoken: "", unspoken: partText }
+                  : { spoken: "", unspoken: "" },
               };
             }
 
@@ -186,10 +198,16 @@ export const usePipecatConversation = ({
                 ? ""
                 : partText;
 
+            // Apply filter
+            const filteredSpoken =
+              botOutputFilter?.spoken !== false ? spokenText : "";
+            const filteredUnspoken =
+              botOutputFilter?.unspoken !== false ? unspokenText : "";
+
             return {
               ...part,
               displayMode,
-              text: { spoken: spokenText, unspoken: unspokenText },
+              text: { spoken: filteredSpoken, unspoken: filteredUnspoken },
             };
           }
         );
@@ -204,7 +222,7 @@ export const usePipecatConversation = ({
 
     // Messages are already normalized (sorted, filtered, deduped, merged) on write.
     return processedMessages;
-  }, [messages, botOutputMessageState, aggregationMetadata]);
+  }, [messages, botOutputMessageState, aggregationMetadata, botOutputFilter]);
 
   return {
     messages: filteredMessages,

--- a/client-react/tests/conversation/filterBotOutputText.test.ts
+++ b/client-react/tests/conversation/filterBotOutputText.test.ts
@@ -1,0 +1,68 @@
+import { filterBotOutputText } from "@/conversation/filterBotOutputText";
+import type { BotOutputText } from "@/conversation/types";
+
+const SAMPLE: BotOutputText = {
+  spoken: "Hello there",
+  unspoken: ", how are you?",
+};
+
+describe("filterBotOutputText", () => {
+  it("returns the text unchanged when no filter is provided", () => {
+    expect(filterBotOutputText(SAMPLE)).toEqual(SAMPLE);
+  });
+
+  it("returns the text unchanged for an empty filter object", () => {
+    expect(filterBotOutputText(SAMPLE, {})).toEqual(SAMPLE);
+  });
+
+  it("treats spoken and unspoken as included by default", () => {
+    expect(
+      filterBotOutputText(SAMPLE, { spoken: true, unspoken: true })
+    ).toEqual(SAMPLE);
+  });
+
+  it("zeroes out the spoken portion when spoken: false", () => {
+    expect(filterBotOutputText(SAMPLE, { spoken: false })).toEqual({
+      spoken: "",
+      unspoken: SAMPLE.unspoken,
+    });
+  });
+
+  it("zeroes out the unspoken portion when unspoken: false", () => {
+    expect(filterBotOutputText(SAMPLE, { unspoken: false })).toEqual({
+      spoken: SAMPLE.spoken,
+      unspoken: "",
+    });
+  });
+
+  it("zeroes out both portions when spoken and unspoken are both false", () => {
+    expect(
+      filterBotOutputText(SAMPLE, { spoken: false, unspoken: false })
+    ).toEqual({ spoken: "", unspoken: "" });
+  });
+
+  it("treats an explicit true the same as default", () => {
+    expect(
+      filterBotOutputText(SAMPLE, { spoken: true, unspoken: false })
+    ).toEqual({
+      spoken: SAMPLE.spoken,
+      unspoken: "",
+    });
+  });
+
+  it("preserves empty-string inputs regardless of filter flags", () => {
+    const empty: BotOutputText = { spoken: "", unspoken: "" };
+    expect(filterBotOutputText(empty)).toEqual(empty);
+    expect(filterBotOutputText(empty, { spoken: false })).toEqual(empty);
+    expect(filterBotOutputText(empty, { unspoken: false })).toEqual(empty);
+  });
+
+  it("does not mutate the input object", () => {
+    const input: BotOutputText = {
+      spoken: SAMPLE.spoken,
+      unspoken: SAMPLE.unspoken,
+    };
+    filterBotOutputText(input, { spoken: false, unspoken: false });
+    expect(input).toEqual(SAMPLE);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a `BotOutputFilter` type and a `botOutputFilter` option on `usePipecatConversation` that controls which portions of each `BotOutputText` (`spoken`, `unspoken`) are returned by the hook.
- The underlying atoms still hold the full data; only the hook's output is filtered. Both flags default to `true`, so existing callers are unaffected.

## Motivation

voice-ui-kit has a [new `textRenderMode` switch](https://github.com/pipecat-ai/voice-ui-kit/pull/118) on its `Conversation` / `ConversationPanel` / `ConsoleTemplate` components with three modes:

- `"karaoke"` (default): spoken text normal, unspoken text muted (current behavior).
- `"spoken"`: only show what the bot has already said — this is the mode that needs the hook to drop the `unspoken` portion, otherwise the karaoke rendering shows it all the time.
- `"unspoken"`: the full LLM text, no highlight sweep — doesn't need the filter but works cleanly with it.

The filter lives here instead of in the UI so any consumer of the hook (not just voice-ui-kit) can opt into the behavior.

## Test plan

- [x] `pnpm --filter @pipecat-ai/client-react test` — 162 tests pass, no behavior change in the default path.
- [x] Verified cross-repo: the textRenderMode PR in voice-ui-kit (#118) consumes this option end-to-end.