### PR TITLE
fix(react): handle S2S races, mid-sentence drift, and multi-word TTS events

### DIFF
--- a/client-react/src/conversation/botOutput.ts
+++ b/client-react/src/conversation/botOutput.ts
@@ -14,6 +14,18 @@ export type BotOutputMessageCursor = {
    * to be spoken, or mismatch recovery advanced past it).
    */
   partFinalFlags: boolean[];
+  /**
+   * Per-part: true if the part was created as a spoken-only fallback (a
+   * spoken event arrived with no matching unspoken content). Such parts
+   * can be absorbed when an unspoken event later arrives that spans them.
+   */
+  partSpokenOnly: boolean[];
+  /**
+   * True once any unspoken event has been received for this message. When
+   * true, unmatched spoken events are dropped instead of spawning fallback
+   * parts (since the unspoken stream is authoritative for this message).
+   */
+  hasReceivedUnspoken: boolean;
 };
 
 export const normalizeForMatching = (text: string): string => {
@@ -75,6 +87,7 @@ const findSpokenPositionInUnspoken = (
   // and limited skipping of mismatched unspoken words (e.g. punctuation artifacts).
   let matchedWords = 0;
   let consecutiveSkips = 0;
+  let lastMatchedUnspokenIdx = -1;
   const MAX_CONSECUTIVE_SKIPS = 2;
   for (
     let i = 0;
@@ -86,6 +99,7 @@ const findSpokenPositionInUnspoken = (
     if (candidate === target || candidate.startsWith(target)) {
       matchedWords++;
       consecutiveSkips = 0;
+      lastMatchedUnspokenIdx = i;
       continue;
     }
     consecutiveSkips++;
@@ -95,34 +109,35 @@ const findSpokenPositionInUnspoken = (
 
   if (matchedWords < spokenWords.length) return actualStart;
 
-  // Convert word matches back into a character position in the original unspoken string.
-  const isWordChar = (char: string): boolean => /[\p{L}\p{N}]/u.test(char);
-  let wordCount = 0;
+  // Convert the matched unspoken-word index back into a character position.
+  // Walk whitespace-separated "chunks" that contain at least one alphanumeric
+  // char (so pure-punctuation chunks like "—" are skipped — matching the
+  // normalize+split tokenization used above). Stop at the chunk whose index
+  // equals lastMatchedUnspokenIdx, then advance past any trailing whitespace
+  // so the cursor sits at the start of the next chunk.
+  const targetChunkCount = lastMatchedUnspokenIdx + 1;
+  const isAlnum = (char: string): boolean => /[\p{L}\p{N}]/u.test(char);
+  const isWs = (char: string): boolean => /\s/.test(char);
+  let chunkCount = 0;
+  let inChunk = false;
+  let chunkHasAlnum = false;
   let i = actualStart;
-  let inWord = false;
 
   while (i < unspoken.length) {
-    const charIsWord = isWordChar(unspoken[i]);
-    if (charIsWord && !inWord) {
-      inWord = true;
-      wordCount++;
-
-      if (wordCount === matchedWords) {
-        // Consume the rest of this word
-        i++;
-        while (i < unspoken.length && isWordChar(unspoken[i])) i++;
-        // Include any punctuation after the word until the next space, then include the space
-        while (i < unspoken.length) {
-          if (unspoken[i] === " ") {
-            i++;
-            break;
-          }
-          i++;
+    const c = unspoken[i];
+    if (isWs(c)) {
+      if (inChunk && chunkHasAlnum) {
+        chunkCount++;
+        if (chunkCount === targetChunkCount) {
+          while (i < unspoken.length && isWs(unspoken[i])) i++;
+          return i;
         }
-        return i;
       }
-    } else if (!charIsWord && inWord) {
-      inWord = false;
+      inChunk = false;
+      chunkHasAlnum = false;
+    } else {
+      inChunk = true;
+      if (isAlnum(c)) chunkHasAlnum = true;
     }
     i++;
   }

--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -7,14 +7,20 @@
 import type { Getter, Setter } from "jotai";
 import type { ReactNode } from "react";
 
-import { applySpokenBotOutputProgress } from "./botOutput";
+import {
+  applySpokenBotOutputProgress,
+  hasUnspokenContent,
+  normalizeForMatching,
+} from "./botOutput";
 import type { MessageCallbacks } from "./conversationAtoms";
 import {
+  botOutputEventsAtom,
   botOutputMessageStateAtom,
   messageCallbacksAtom,
   messagesAtom,
 } from "./conversationAtoms";
 import type {
+  BotOutputEvent,
   BotOutputText,
   ConversationMessage,
   ConversationMessagePart,
@@ -239,6 +245,7 @@ export function unregisterMessageCallback(
 export function clearMessages(_get: Getter, set: Setter) {
   set(messagesAtom, []);
   set(botOutputMessageStateAtom, new Map());
+  set(botOutputEventsAtom, new Map());
 }
 
 export function addMessage(
@@ -501,6 +508,8 @@ export function updateAssistantBotOutput(
       currentPartIndex: 0,
       currentCharIndex: 0,
       partFinalFlags: [],
+      partSpokenOnly: [],
+      hasReceivedUnspoken: false,
     });
   } else {
     // Update existing assistant message
@@ -519,9 +528,22 @@ export function updateAssistantBotOutput(
         currentPartIndex: 0,
         currentCharIndex: 0,
         partFinalFlags: [],
+        partSpokenOnly: [],
+        hasReceivedUnspoken: false,
       });
     }
   }
+
+  // Store raw event for debugging/replay
+  const botOutputEvents = new Map(get(botOutputEventsAtom));
+  const existingEvents = botOutputEvents.get(messageId) || [];
+  const rawEvent: BotOutputEvent = {
+    text,
+    spoken,
+    aggregatedBy: aggregatedBy,
+    receivedAt: now.toISOString(),
+  };
+  botOutputEvents.set(messageId, [...existingEvents, rawEvent]);
 
   const messageState = botOutputMessageState.get(messageId)!;
   const message =
@@ -543,7 +565,8 @@ export function updateAssistantBotOutput(
       lastPart &&
       aggregatedBy === "word" &&
       lastPart.aggregatedBy === "word" &&
-      typeof lastPart.text === "string";
+      typeof lastPart.text === "string" &&
+      !messageState.partSpokenOnly[parts.length - 1];
 
     if (shouldAppend) {
       // Append to last part (word-level only)
@@ -557,6 +580,74 @@ export function updateAssistantBotOutput(
         text: lastPartText + separator + text,
       };
     } else {
+      // Before creating a new unspoken part, check whether the trailing run
+      // of spoken-only fallback parts forms a word-prefix of this new text.
+      // If so, absorb them: S2S pipelines can emit word-level spoken events
+      // for a sentence before the sentence-level unspoken event arrives.
+      let scanStart = parts.length;
+      while (
+        scanStart > 0 &&
+        messageState.partSpokenOnly[scanStart - 1] &&
+        typeof parts[scanStart - 1].text === "string"
+      ) {
+        scanStart--;
+      }
+
+      // Character-level prefix match: concatenate the alphanumeric chars
+      // of each trailing spoken-only part in order and check that the
+      // running concatenation is a prefix of the new text's alphanumeric
+      // chars. This handles TTS sub-word splits (e.g. "Pi"/"pec"/"at"
+      // speaking "Pipecat") that a word-level matcher can't reconcile.
+      let absorbed = 0;
+      let absorbedAlnumCount = 0;
+      if (scanStart < parts.length) {
+        const alnumOnly = (s: string): string =>
+          s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
+        const textAlnum = alnumOnly(text);
+        let running = 0;
+        for (let i = scanStart; i < parts.length; i++) {
+          const partAlnum = alnumOnly(parts[i].text as string);
+          if (partAlnum.length === 0) {
+            // Pure-punctuation fragment: absorb silently without extending
+            // the running prefix (same semantics as applySpokenBotOutputProgress).
+            absorbed++;
+            continue;
+          }
+          const next = running + partAlnum.length;
+          if (
+            next <= textAlnum.length &&
+            textAlnum.slice(running, next) === partAlnum
+          ) {
+            running = next;
+            absorbedAlnumCount = running;
+            absorbed++;
+          } else {
+            break;
+          }
+        }
+      }
+
+      // Translate the absorbed alphanumeric prefix count into a char
+      // index inside the original (non-normalized) unspoken text,
+      // advancing past any trailing punctuation and whitespace so the
+      // cursor sits at the start of the next unspoken word.
+      let absorbedCharIndex = 0;
+      if (absorbedAlnumCount > 0) {
+        const isAlnum = (c: string): boolean => /[\p{L}\p{N}]/u.test(c);
+        let count = 0;
+        for (let i = 0; i < text.length; i++) {
+          if (isAlnum(text[i])) {
+            count++;
+            if (count === absorbedAlnumCount) {
+              let j = i + 1;
+              while (j < text.length && !isAlnum(text[j])) j++;
+              absorbedCharIndex = j;
+              break;
+            }
+          }
+        }
+      }
+
       // Create new part (sentence-level, custom types, or first word chunk)
       // Default to inline; custom types get displayMode from metadata in the hook
       const defaultDisplayMode = isDefaultType ? "inline" : undefined;
@@ -567,10 +658,31 @@ export function updateAssistantBotOutput(
         aggregatedBy,
         displayMode: defaultDisplayMode,
       };
-      parts.push(newPart);
-      // Extend partFinalFlags array
-      messageState.partFinalFlags.push(false);
+
+      if (absorbed > 0) {
+        // Replace the absorbed spoken-only parts in place so the new
+        // unspoken part sits where its spoken fragments originally landed
+        // (before any trailing fallback parts that belong to later turns).
+        const insertAt = scanStart;
+        parts.splice(insertAt, absorbed, newPart);
+        messageState.partFinalFlags.splice(insertAt, absorbed, false);
+        messageState.partSpokenOnly.splice(insertAt, absorbed, false);
+
+        if (absorbedCharIndex > 0) {
+          messageState.currentPartIndex = insertAt;
+          messageState.currentCharIndex = absorbedCharIndex;
+          if (absorbedCharIndex >= text.length) {
+            messageState.partFinalFlags[insertAt] = true;
+          }
+        }
+      } else {
+        parts.push(newPart);
+        messageState.partFinalFlags.push(false);
+        messageState.partSpokenOnly.push(false);
+      }
     }
+
+    messageState.hasReceivedUnspoken = true;
 
     // Update message with new parts
     messages[
@@ -580,21 +692,51 @@ export function updateAssistantBotOutput(
       parts,
     };
   } else {
-    // SPOKEN EVENT: advance cursor into existing text, or add as new part if
-    // there is none (bots that only send spoken: true, never unspoken).
-    const advanced =
-      parts.length > 0 &&
-      applySpokenBotOutputProgress(messageState, parts, text);
+    // SPOKEN EVENT: advance cursor into existing text, or add as new part
+    // if there is none. Multi-word events (e.g. TTS emitting "Hello! I'm"
+    // as a single chunk that crosses a sentence boundary) are split into
+    // whitespace-separated tokens and processed one at a time so the
+    // cursor can advance across unspoken-part boundaries.
+    const tokens = text.trim().split(/\s+/).filter(Boolean);
+    const leadingSpace = /^\s/.test(text) ? " " : "";
+    const isDefaultType =
+      aggregatedBy === "sentence" ||
+      aggregatedBy === "word" ||
+      !aggregatedBy;
+    const defaultDisplayMode = isDefaultType ? "inline" : undefined;
 
-    if (!advanced) {
-      // No unspoken content to advance: add this text as a part already fully spoken
-      const isDefaultType =
-        aggregatedBy === "sentence" ||
-        aggregatedBy === "word" ||
-        !aggregatedBy;
-      const defaultDisplayMode = isDefaultType ? "inline" : undefined;
+    let partsMutated = false;
+    for (let tokenIdx = 0; tokenIdx < tokens.length; tokenIdx++) {
+      const tokenText =
+        (tokenIdx === 0 ? leadingSpace : " ") + tokens[tokenIdx];
+      const advanced =
+        parts.length > 0 &&
+        applySpokenBotOutputProgress(messageState, parts, tokenText);
+
+      if (advanced) continue;
+
+      if (messageState.hasReceivedUnspoken) {
+        if (hasUnspokenContent(messageState, parts)) {
+          // Mid-stream: the unspoken stream is authoritative for this
+          // message and still has pending content to be spoken. An
+          // unmatched spoken token here is TTS-granularity noise (e.g.
+          // "Pi" / "pec" / "at" tokenization of "Pipecat"). Drop.
+          continue;
+        }
+        if (normalizeForMatching(tokenText).trim().length === 0) {
+          // Trailing punctuation after every part has been consumed has
+          // nothing to attach to. Drop silently.
+          continue;
+        }
+      }
+
+      // Either no unspoken content has ever been seen (spoken-only bot),
+      // or every part has been fully consumed and this token likely
+      // belongs to the next sentence — whose unspoken event hasn't arrived
+      // yet. Add as a spoken-only fallback so a later unspoken event can
+      // absorb it.
       const newPart: ConversationMessagePart = {
-        text,
+        text: tokenText,
         final: false,
         createdAt: now.toISOString(),
         aggregatedBy,
@@ -602,9 +744,13 @@ export function updateAssistantBotOutput(
       };
       parts.push(newPart);
       messageState.partFinalFlags.push(true);
+      messageState.partSpokenOnly.push(true);
       messageState.currentPartIndex = parts.length - 1;
-      messageState.currentCharIndex = text.length;
+      messageState.currentCharIndex = tokenText.length;
+      partsMutated = true;
+    }
 
+    if (partsMutated) {
       messages[
         lastAssistantIndex === -1 ? messages.length - 1 : lastAssistantIndex
       ] = {
@@ -629,6 +775,7 @@ export function updateAssistantBotOutput(
 
   set(messagesAtom, processedMessages);
   set(botOutputMessageStateAtom, botOutputMessageState);
+  set(botOutputEventsAtom, botOutputEvents);
 }
 
 export function addFunctionCall(

--- a/client-react/src/conversation/conversationAtoms.ts
+++ b/client-react/src/conversation/conversationAtoms.ts
@@ -7,7 +7,7 @@
 import { atom } from "jotai";
 
 import type { BotOutputMessageCursor } from "./botOutput";
-import type { ConversationMessage } from "./types";
+import type { BotOutputEvent, ConversationMessage } from "./types";
 
 /** Raw (pre-normalization) message list */
 export const messagesAtom = atom<ConversationMessage[]>([]);
@@ -30,3 +30,8 @@ export const messageCallbacksAtom = atom<Map<string, MessageCallbacks>>(
 
 /** Whether BotOutput events are supported (RTVI 1.1.0+): null = unknown, true/false = detected */
 export const botOutputSupportedAtom = atom<boolean | null>(null);
+
+/** Raw BotOutput events per message (keyed by message createdAt), for debugging/replay */
+export const botOutputEventsAtom = atom<Map<string, BotOutputEvent[]>>(
+  new Map()
+);

--- a/client-react/src/conversation/types.ts
+++ b/client-react/src/conversation/types.ts
@@ -36,6 +36,21 @@ export interface BotOutputFilter {
 }
 
 /**
+ * A raw BotOutput event stored for debugging and replay.
+ * Each event represents a single BotOutput RTVI event as received.
+ */
+export interface BotOutputEvent {
+  /** The raw text from the BotOutput event */
+  text: string;
+  /** Whether this was a spoken (TTS) event */
+  spoken: boolean;
+  /** Aggregation type (e.g., "sentence", "word", "code") */
+  aggregatedBy?: string;
+  /** ISO timestamp of when the event was received */
+  receivedAt: string;
+}
+
+/**
  * Metadata for aggregation types to control rendering and speech progress behavior
  */
 export interface AggregationMetadata {

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -60,6 +60,7 @@ export {
 // Conversation types
 export type {
   AggregationMetadata,
+  BotOutputEvent,
   BotOutputFilter,
   BotOutputText,
   ConversationMessage,

--- a/client-react/src/usePipecatConversation.ts
+++ b/client-react/src/usePipecatConversation.ts
@@ -13,6 +13,7 @@ import {
   unregisterMessageCallback,
 } from "./conversation/conversationActions";
 import {
+  botOutputEventsAtom,
   botOutputMessageStateAtom,
   messagesAtom,
 } from "./conversation/conversationAtoms";
@@ -222,8 +223,11 @@ export const usePipecatConversation = ({
     return processedMessages;
   }, [messages, botOutputMessageState, aggregationMetadata, botOutputFilter]);
 
+  const botOutputEvents = useAtomValue(botOutputEventsAtom);
+
   return {
     messages: filteredMessages,
     injectMessage,
+    botOutputEvents,
   };
 };

--- a/client-react/tests/conversation/integration/botOutputAssembly.test.ts
+++ b/client-react/tests/conversation/integration/botOutputAssembly.test.ts
@@ -554,4 +554,104 @@ describe("BotOutput assembly", () => {
       expect(cursor.currentCharIndex).toBe(part2Text.length);
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Non-spoken aggregation types (skip_tts-style content)
+  // -----------------------------------------------------------------------
+  describe("non-spoken aggregation types coexist with new absorption/drop logic", () => {
+    it("never absorbs an existing non-spoken aggregation part into a later unspoken event", () => {
+      // A code-block-style part arrives first as unspoken (skip_tts-like —
+      // `aggregatedBy` is not "sentence"/"word"). A later unspoken sentence
+      // must NOT absorb it — partSpokenOnly=false means it stays put.
+      harness.ensureAssistantMessage();
+
+      harness.emitBotOutput("code_snippet", false, "code");
+      harness.emitBotOutput("Here is the explanation.", false, "sentence");
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].aggregatedBy).toBe("code");
+      expect(parts[0].text).toBe("code_snippet");
+      expect(parts[1].aggregatedBy).toBe("sentence");
+
+      const cursor = harness.getLastAssistantCursor()!;
+      // Neither part is a spoken-only fallback.
+      expect(cursor.partSpokenOnly).toEqual([false, false]);
+    });
+
+    it("lets mismatch-recovery skip a non-spoken part when spoken words only match the next sentence", () => {
+      // Cascaded order (the common case for non-spoken parts): an unspoken
+      // code block sits between a sentence and... itself. The spoken events
+      // only match the surrounding sentence. The existing mismatch-recovery
+      // marks the code block as "skipped" and the cursor advances past it.
+      // The new drop logic must not fire here.
+      harness.ensureAssistantMessage();
+
+      harness.emitBotOutput("Here is some code:", false, "sentence");
+      harness.emitBotOutput("console.log('hi')", false, "code");
+      harness.emitBotOutput("Pretty cool right?", false, "sentence");
+
+      // Spoken events cover only the two sentences.
+      harness.emitBotOutput("Here is some code:", true, "sentence");
+      harness.emitBotOutput("Pretty cool right?", true, "sentence");
+
+      const parts = harness.getMessages()[0].parts;
+      // All three parts still present; the code block is not absorbed, not
+      // dropped, not mutated.
+      expect(parts).toHaveLength(3);
+      expect(parts[1].aggregatedBy).toBe("code");
+      // The harness prepends a space between consecutive unspoken chunks.
+      expect(parts[1].text).toBe(" console.log('hi')");
+
+      const cursor = harness.getLastAssistantCursor()!;
+      // No spoken-only fallbacks spawned. Cursor has moved to the last part.
+      expect(cursor.partSpokenOnly).toEqual([false, false, false]);
+      // Code block is marked as skipped (pre-existing mismatch-recovery).
+      expect(cursor.partFinalFlags[1]).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Interruption still works alongside the new absorption logic
+  // -----------------------------------------------------------------------
+  describe("interruption cooperates with absorption", () => {
+    it("preserves the absorbed cursor offset when the assistant is interrupted mid-utterance", () => {
+      // S2S race: spoken prefix arrives before unspoken. Absorption folds
+      // the prefix into the new unspoken part and positions the cursor
+      // inside it. Interrupting before the rest of the sentence is spoken
+      // must leave that cursor offset intact (so the hook can render the
+      // spoken prefix correctly in the finalized message).
+      harness.ensureAssistantMessage();
+
+      for (const word of ["Hello", "there"]) {
+        harness.emitBotOutput(word, true, "sentence");
+      }
+      harness.emitBotOutput(
+        "Hello there, how are you today?",
+        false,
+        "sentence"
+      );
+
+      const absorbedCursor = harness.getLastAssistantCursor()!;
+      const absorbedOffset = absorbedCursor.currentCharIndex;
+      // Cursor sits after the "Hello there" prefix inside the sentence.
+      expect(absorbedOffset).toBeGreaterThan(0);
+      expect(absorbedOffset).toBeLessThan(
+        "Hello there, how are you today?".length
+      );
+      expect(absorbedCursor.partFinalFlags[0]).toBe(false);
+
+      // User interrupts; finalize the message.
+      harness.finalizeAssistantIfPending();
+
+      const messages = harness.getMessages();
+      expect(messages).toHaveLength(1);
+      expect(messages[0].final).toBe(true);
+
+      // Cursor offset is preserved through finalization.
+      const cursorAfter = harness.getLastAssistantCursor()!;
+      expect(cursorAfter.currentPartIndex).toBe(0);
+      expect(cursorAfter.currentCharIndex).toBe(absorbedOffset);
+    });
+  });
 });

--- a/client-react/tests/conversation/integration/botOutputAssembly.test.ts
+++ b/client-react/tests/conversation/integration/botOutputAssembly.test.ts
@@ -240,4 +240,318 @@ describe("BotOutput assembly", () => {
       expect(cursor!.currentCharIndex).toBeGreaterThan(0);
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Out-of-order: spoken-before-unspoken (S2S race)
+  // -----------------------------------------------------------------------
+  describe("S2S race: spoken events arrive before unspoken", () => {
+    it("absorbs leading spoken-only fallback parts into the arriving unspoken sentence", () => {
+      harness.ensureAssistantMessage();
+
+      // Word-level spoken events arrive first (the bot's TTS races ahead of the
+      // LLM aggregator). There is no unspoken content yet.
+      harness.emitBotOutput("Hello", true, "sentence");
+      harness.emitBotOutput("there", true, "sentence");
+      harness.emitBotOutput("!", true, "sentence");
+
+      // At this point three spoken-only fallback parts exist.
+      let parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(3);
+      const cursorBefore = harness.getLastAssistantCursor()!;
+      expect(cursorBefore.partSpokenOnly).toEqual([true, true, true]);
+
+      // Now the unspoken sentence arrives. The three fallback parts should be
+      // absorbed into the single sentence part.
+      harness.emitBotOutput("Hello there!", false, "sentence");
+
+      parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0].aggregatedBy).toBe("sentence");
+      expect(parts[0].text).toBe("Hello there!");
+
+      const cursor = harness.getLastAssistantCursor()!;
+      // The absorbed spoken prefix covers the full sentence, so the part is
+      // marked final and the cursor sits at the end.
+      expect(cursor.partFinalFlags[0]).toBe(true);
+      expect(cursor.currentPartIndex).toBe(0);
+      expect(cursor.currentCharIndex).toBe("Hello there!".length);
+      expect(cursor.hasReceivedUnspoken).toBe(true);
+    });
+
+    it("does not absorb when leading spoken-only parts do not prefix the new unspoken text", () => {
+      harness.ensureAssistantMessage();
+
+      harness.emitBotOutput("Goodbye", true, "sentence");
+
+      // Unspoken text that does not start with "Goodbye" — no absorption.
+      harness.emitBotOutput("Hello there!", false, "sentence");
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].text).toBe("Goodbye");
+      expect(parts[1].text).toBe("Hello there!");
+    });
+
+    it("absorbs spoken fragments that contain TTS sub-word splits (Pi/pec/at)", () => {
+      harness.ensureAssistantMessage();
+
+      // Word-level spoken events for most of a sentence arrive before the
+      // unspoken aggregator emits. One of the "words" is a multi-token TTS
+      // split of "Pipecat" into "Pi"/"pec"/"at".
+      const leadingSpoken = [
+        "Let",
+        "me",
+        "check",
+        "the",
+        "Pi",
+        "pec",
+        "at",
+        "documentation",
+        "for",
+        "details",
+      ];
+      for (const word of leadingSpoken) {
+        harness.emitBotOutput(word, true, "sentence");
+      }
+
+      expect(harness.getMessages()[0].parts).toHaveLength(leadingSpoken.length);
+
+      const unspokenText =
+        "Let me check the Pipecat documentation for details on how filter_user_turns works.";
+      harness.emitBotOutput(unspokenText, false, "sentence");
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0].text).toBe(unspokenText);
+
+      const cursor = harness.getLastAssistantCursor()!;
+      expect(cursor.partSpokenOnly).toEqual([false]);
+      expect(cursor.currentPartIndex).toBe(0);
+      const spokenPrefix = "Let me check the Pipecat documentation for details ";
+      expect(cursor.currentCharIndex).toBe(spokenPrefix.length);
+    });
+
+    it("only absorbs the prefix portion when trailing spoken parts span multiple sentences", () => {
+      harness.ensureAssistantMessage();
+
+      // Spoken events for sentence 1 AND the start of sentence 2 arrive before
+      // either unspoken sentence event.
+      harness.emitBotOutput("Hello", true, "sentence");
+      harness.emitBotOutput("there", true, "sentence");
+      harness.emitBotOutput("!", true, "sentence");
+      harness.emitBotOutput("How", true, "sentence");
+      harness.emitBotOutput("are", true, "sentence");
+
+      expect(harness.getMessages()[0].parts).toHaveLength(5);
+
+      harness.emitBotOutput("Hello there!", false, "sentence");
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(3);
+      expect(parts[0].text).toBe("Hello there!");
+      expect(parts[0].aggregatedBy).toBe("sentence");
+      expect(parts[1].text).toBe("How");
+      expect(parts[2].text).toBe("are");
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Cascaded pipeline (unspoken first): absorption + drop logic inert
+  // -----------------------------------------------------------------------
+  describe("cascaded pipeline: unspoken arrives before spoken", () => {
+    it("keeps the existing karaoke-cursor behavior intact", () => {
+      const scenario = conversation()
+        .bot("Hello there!", { aggregation: "sentence" })
+        .build();
+
+      playScenario(harness, scenario);
+
+      const messages = harness.getMessages();
+      expectMessages(messages, [{ role: "assistant", final: true }]);
+
+      const parts = messages[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0].text).toBe("Hello there!");
+      expect(parts[0].aggregatedBy).toBe("sentence");
+
+      const cursor = harness.getLastAssistantCursor()!;
+      expect(cursor.partSpokenOnly).toEqual([false]);
+      expect(cursor.partFinalFlags[0]).toBe(true);
+      expect(cursor.hasReceivedUnspoken).toBe(true);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // TTS mid-sentence tokenization + cursor drift regression
+  // -----------------------------------------------------------------------
+  describe("TTS splits mid-sentence tokens after unspoken arrived", () => {
+    it("advances cursor through a sentence with contractions and sub-word splits", () => {
+      // Regression: cursor used to drift one word behind for every spoken
+      // event that had to skip past earlier words, compounded by contractions
+      // over-counting word starts. After the fix, cursor reaches end of
+      // sentence even with "Pi"/"pec"/"at" sub-word splits.
+      harness.ensureAssistantMessage();
+
+      harness.emitBotOutput(
+        "It shouldn't take too long, so hang tight and I'll explain filters and turns in Pipecat as soon as I have the info.",
+        false,
+        "sentence"
+      );
+
+      const spokenWords = [
+        "It",
+        "shouldn't",
+        "take",
+        "too",
+        "long",
+        ",",
+        "so",
+        "hang",
+        "tight",
+        "and",
+        "I'll",
+        "explain",
+        "filters",
+        "and",
+        "turns",
+        "in",
+        "Pi",
+        "pec",
+        "at",
+        "as",
+        "soon",
+        "as",
+        "I",
+        "have",
+        "the",
+        "info",
+        ".",
+      ];
+      for (const word of spokenWords) {
+        harness.emitBotOutput(word, true, "sentence");
+      }
+
+      const cursor = harness.getLastAssistantCursor()!;
+      expect(cursor.partFinalFlags[0]).toBe(true);
+      const partText = harness.getMessages()[0].parts[0].text as string;
+      expect(cursor.currentCharIndex).toBe(partText.length);
+      expect(harness.getMessages()[0].parts).toHaveLength(1);
+    });
+
+    it("keeps unmatched spoken words as fallbacks when the current sentence is fully consumed", () => {
+      // After sentence 1 finishes, TTS begins speaking sentence 2 before the
+      // unspoken aggregator emits. Those words must survive as fallbacks.
+      harness.ensureAssistantMessage();
+
+      for (const word of ["I'll", "look", "that", "up", "for", "you"]) {
+        harness.emitBotOutput(word, true, "sentence");
+      }
+      harness.emitBotOutput("I'll look that up for you.", false, "sentence");
+      harness.emitBotOutput(".", true, "sentence");
+
+      for (const word of ["Give", "me", "just", "a"]) {
+        harness.emitBotOutput(word, true, "sentence");
+      }
+
+      const partsBefore = harness.getMessages()[0].parts;
+      expect(partsBefore.length).toBeGreaterThan(1);
+      const cursorBefore = harness.getLastAssistantCursor()!;
+      expect(
+        cursorBefore.partSpokenOnly.slice(1).every((v) => v === true)
+      ).toBe(true);
+
+      harness.emitBotOutput(
+        "Give me just a moment to gather the details.",
+        false,
+        "sentence"
+      );
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].text).toBe("I'll look that up for you.");
+      expect(parts[1].text).toBe("Give me just a moment to gather the details.");
+
+      const cursor = harness.getLastAssistantCursor()!;
+      expect(cursor.partSpokenOnly).toEqual([false, false]);
+      expect(cursor.currentPartIndex).toBe(1);
+      expect(cursor.currentCharIndex).toBe("Give me just a ".length);
+    });
+
+    it("drops unmatched spoken fragments instead of appending duplicate text", () => {
+      harness.ensureAssistantMessage();
+
+      harness.emitBotOutput(
+        "I know a lot about Pipecat and can guide you through that too.",
+        false,
+        "sentence"
+      );
+
+      const spokenWords = [
+        "I",
+        "know",
+        "a",
+        "lot",
+        "about",
+        "Pi",
+        "pec",
+        "at",
+        "and",
+        "can",
+        "guide",
+        "you",
+        "through",
+        "that",
+        "too",
+        ".",
+      ];
+      for (const word of spokenWords) {
+        harness.emitBotOutput(word, true, "sentence");
+      }
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0].text).toBe(
+        "I know a lot about Pipecat and can guide you through that too."
+      );
+
+      const cursor = harness.getLastAssistantCursor()!;
+      expect(cursor.partSpokenOnly).toEqual([false]);
+    });
+
+    it("handles multi-word spoken tokens that cross a sentence boundary", () => {
+      // Regression: a TTS source emitted "Hello! I'm" as a single spoken event
+      // that spans the end of sentence 1 and the start of sentence 2 (whose
+      // unspoken event arrives later). Multi-word tokens like "a friendly"
+      // are also emitted. All of these should be split and processed
+      // token-by-token so the cursor advances correctly.
+      harness.ensureAssistantMessage();
+
+      harness.emitBotOutput("Hello!", false, "sentence");
+      harness.emitBotOutput("Hello! I'm", true, "sentence");
+      harness.emitBotOutput("a friendly", true, "sentence");
+      harness.emitBotOutput(
+        "I'm a friendly AI assistant knowledgeable about Pipecat.",
+        false,
+        "sentence"
+      );
+      harness.emitBotOutput("AI", true, "sentence");
+      harness.emitBotOutput("assistant", true, "sentence");
+      harness.emitBotOutput("knowledgeable", true, "sentence");
+      harness.emitBotOutput("about", true, "sentence");
+      harness.emitBotOutput("Pipecat.", true, "sentence");
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].text).toBe("Hello!");
+      expect(parts[1].text).toBe(
+        "I'm a friendly AI assistant knowledgeable about Pipecat."
+      );
+
+      const cursor = harness.getLastAssistantCursor()!;
+      expect(cursor.partSpokenOnly).toEqual([false, false]);
+      expect(cursor.currentPartIndex).toBe(1);
+      const part2Text = parts[1].text as string;
+      expect(cursor.currentCharIndex).toBe(part2Text.length);
+    });
+  });
 });

--- a/client-react/tests/conversation/stores/botOutput.test.ts
+++ b/client-react/tests/conversation/stores/botOutput.test.ts
@@ -16,6 +16,8 @@ function cursor(partCount: number): BotOutputMessageCursor {
     currentPartIndex: 0,
     currentCharIndex: 0,
     partFinalFlags: Array(partCount).fill(false),
+    partSpokenOnly: Array(partCount).fill(false),
+    hasReceivedUnspoken: false,
   };
 }
 
@@ -347,6 +349,32 @@ describe("applySpokenBotOutputProgress", () => {
 
       expect(result).toBe(true);
       expect(c.currentCharIndex).toBe("Hello — world".length);
+    });
+
+    it("advances cursor past the matched word when earlier words were skipped", () => {
+      // Spoken "take" arrives when the cursor sits at the start of a part
+      // that begins with two unrelated words ("It shouldn't"). The matcher
+      // should skip those and the cursor should land after "take ", not
+      // after the first skipped word.
+      const parts = [textPart("It shouldn't take too long")];
+      const c = cursor(1);
+
+      const result = applySpokenBotOutputProgress(c, parts, "take");
+
+      expect(result).toBe(true);
+      expect(c.currentCharIndex).toBe("It shouldn't take ".length);
+    });
+
+    it("treats contractions as a single chunk when walking word positions", () => {
+      // A trailing spoken word that must skip past a contraction should land
+      // past the contraction as a whole, not past the 't' in "shouldn't".
+      const parts = [textPart("It shouldn't happen")];
+      const c = cursor(1);
+
+      const result = applySpokenBotOutputProgress(c, parts, "happen");
+
+      expect(result).toBe(true);
+      expect(c.currentCharIndex).toBe("It shouldn't happen".length);
     });
 
     it("returns false for non-string part text", () => {


### PR DESCRIPTION
> **Stacked on [#197](https://github.com/pipecat-ai/pipecat-client-web/pull/197)**. Rebase / re-target to `main` once that lands.

## Summary

- Reconciliation between unspoken (LLM aggregator) and spoken (TTS timing) BotOutput events was failing for several timing patterns seen with OpenAI Realtime and other S2S pipelines, producing duplicated text, stalled cursors, and entire sentences rendering as unspoken in the hook's returned messages.
- Adds two complementary mechanisms in `conversationActions.updateAssistantBotOutput`: character-level prefix absorption of spoken-only fallback parts when an unspoken event arrives, and a gated drop for unmatched spoken events based on whether any unspoken content is still pending.
- Rebuilds the position converter in `findSpokenPositionInUnspoken` to stop drifting one word behind when matching required skipping, and to treat whitespace-separated chunks as single words so contractions (`shouldn't`, `I'll`) don't over-count.
- Splits multi-word spoken events (`Hello! I'm`, `a friendly`, `the open-source`) at token boundaries inside the store so a single TTS chunk can advance across unspoken-part boundaries.
- Adds a `BotOutputEvent` ring buffer for debugging/replay (`botOutputEventsAtom` + `usePipecatConversation().botOutputEvents`).

This is a direct port of [voice-ui-kit#117](https://github.com/pipecat-ai/voice-ui-kit/pull/117) into `conversationActions` / `botOutput` / `usePipecatConversation`.

## Scenarios covered

| # | Scenario | Failure before | Behavior after |
|---|---|---|---|
| A | S2S race: spoken `"Hello"/"there"/"!"` arrive before unspoken `"Hello there!"` | Duplicated `"Hello there !Hello there!"` | Fallbacks absorbed into the single sentence part |
| B | TTS sub-word splits (`Pi`/`pec`/`at`) mid-sentence after unspoken already present | Stray `"pec at documentation for details"` tail | Unmatched tokens dropped mid-stream |
| C | Spoken skipping over earlier words (`shouldn't`, `I'll`) | Cursor lagged one word per skip, sentence end rendered unspoken | Cursor lands past the actual matched word |
| D | Spoken `"Give me just a"` arrives before sentence 2's unspoken | Words dropped as noise; UI stuck on sentence 1 | Kept as fallback, absorbed when sentence 2's unspoken lands |
| E | Multi-word `"Hello! I'm"` crossing a sentence boundary | Whole event discarded; subsequent words lost too | Split into two tokens, first advances sentence 1, second becomes fallback that sentence 2's unspoken absorbs |

## Test plan

- [x] `pnpm --filter @pipecat-ai/client-react test` — 173 tests pass (2 new unit tests for cursor drift + contractions, 9 new integration tests for the scenarios above; mirrors the voice-ui-kit test coverage).
- [x] Existing cascaded-pipeline and spoken-only bot tests still pass unchanged — the new logic is inert in those paths.