### PR TITLE
fix(client-js): only warn on deprecated onBotTranscript when subscribed

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -351,7 +351,10 @@ export class PipecatClient extends RTVIEventEmitter {
         this.emit(RTVIEvent.BotOutput, data);
       },
       onBotTranscript: (text) => {
-        if (!this._botTranscriptionWarned) {
+        const hasSubscriber =
+          !!options?.callbacks?.onBotTranscript ||
+          this.listenerCount(RTVIEvent.BotTranscript) > 0;
+        if (hasSubscriber && !this._botTranscriptionWarned) {
           logger.warn(
             "[Pipecat Client] Bot transcription is deprecated. Please use the onBotOutput instead."
           );


### PR DESCRIPTION
## Summary

- The `onBotTranscript` deprecation warning fires inside the wrapped transport callback, so it ran on every `bot-transcription` frame the server sent, regardless of whether any client code was actually using the deprecated API.
- For clients that have already migrated to `onBotOutput`, this produced repeat log noise they had no way to silence short of updating the server.
- Gate the warning on a real subscriber being present: either `options.callbacks.onBotTranscript` was supplied at construction, or something has attached a listener for `RTVIEvent.BotTranscript`. The existing `_botTranscriptionWarned` latch still ensures it fires at most once per session.

## Test plan

- [ ] With no `onBotTranscript` callback and no `.on(RTVIEvent.BotTranscript, ...)` listener, connect to a bot that still emits `bot-transcription` frames and confirm no deprecation warning is logged.
- [ ] Pass `onBotTranscript` via `options.callbacks` and confirm the warning is logged exactly once on the first frame.
- [ ] Subscribe via `client.on(RTVIEvent.BotTranscript, ...)` before connecting and confirm the warning is logged exactly once on the first frame.
- [ ] Subscribe to both callback and event listener and confirm the warning still only fires once.

🤖 Generated with [Claude Code](https://claude.com/claude-code)