### PR TITLE
feat(js): add MediaState lifecycle on PipecatClient

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -15,6 +15,8 @@ import {
   BotReadyData,
   BotTTSTextData,
   ClientMessageData,
+  DeviceErrorReason,
+  DeviceStatus,
   ErrorData,
   LLMContextMessage,
   LLMFunctionCallData,
@@ -23,6 +25,7 @@ import {
   LLMFunctionCallResultResponse,
   LLMFunctionCallStartedData,
   LLMFunctionCallStoppedData,
+  MediaState,
   Participant,
   PipecatMetricsData,
   RTVIEvent,
@@ -57,6 +60,31 @@ export type FunctionCallParams = {
   arguments: Record<string, unknown>;
 };
 
+/**
+ * Map a DeviceErrorType onto a DeviceErrorReason that captures the per-device
+ * failure mode. Speaker-affecting errors are not represented here because
+ * MediaState only tracks mic and cam.
+ */
+function deviceErrorReasonFromType(
+  type: RTVIErrors.DeviceErrorType
+): DeviceErrorReason {
+  switch (type) {
+    case "in-use":
+      return "already-in-use";
+    case "permissions":
+      return "blocked";
+    case "not-found":
+      return "not-found";
+    case "undefined-mediadevices":
+      return "not-supported";
+    case "constraints":
+      return "invalid-constraints";
+    case "unknown":
+    default:
+      return "unknown";
+  }
+}
+
 export type FunctionCallCallback = (
   fn: FunctionCallParams
 ) => Promise<LLMFunctionCallResult | void>;
@@ -87,6 +115,7 @@ export type RTVIEventCallbacks = Partial<{
   onMicUpdated: (mic: MediaDeviceInfo) => void;
   onSpeakerUpdated: (speaker: MediaDeviceInfo) => void;
   onDeviceError: (error: RTVIErrors.DeviceError) => void;
+  onMediaStateChanged: (mediaState: MediaState) => void;
   onTrackStarted: (track: MediaStreamTrack, participant?: Participant) => void;
   onTrackStopped: (track: MediaStreamTrack, participant?: Participant) => void;
   onScreenTrackStarted: (
@@ -182,6 +211,14 @@ export class PipecatClient extends RTVIEventEmitter {
   private _botTranscriptionWarned = false;
   private _llmFunctionCallWarned = false;
 
+  // Per-device device state. Independent of TransportState — driven by
+  // initDevices() and DeviceError events, never by transport connect/disconnect.
+  // See common_types.ts for the rationale and the daily-react reference.
+  private _mediaState: MediaState = {
+    mic: { state: "uninitialized" },
+    cam: { state: "uninitialized" },
+  };
+
   constructor(options: PipecatClientOptions) {
     super();
 
@@ -275,10 +312,14 @@ export class PipecatClient extends RTVIEventEmitter {
         this.emit(RTVIEvent.AvailableSpeakersUpdated, speakers);
       },
       onCamUpdated: (cam) => {
+        // Real device selected → permission was granted. Upgrade MediaState
+        // (no-op if already granted, sticky if blocked / in-use / etc).
+        if (cam?.deviceId) this._markDeviceGranted("cam");
         options?.callbacks?.onCamUpdated?.(cam);
         this.emit(RTVIEvent.CamUpdated, cam);
       },
       onMicUpdated: (mic) => {
+        if (mic?.deviceId) this._markDeviceGranted("mic");
         options?.callbacks?.onMicUpdated?.(mic);
         this.emit(RTVIEvent.MicUpdated, mic);
       },
@@ -287,6 +328,12 @@ export class PipecatClient extends RTVIEventEmitter {
         this.emit(RTVIEvent.SpeakerUpdated, speaker);
       },
       onDeviceError: (error) => {
+        // Classify into MediaState in real time. Works the same whether the
+        // error fires during an initDevices() call (mid-await) or out of band
+        // (e.g. devicechange-driven). The post-transport Permissions API
+        // re-query in initDevices() then has the final word for any 'denied'
+        // override.
+        this._classifyAndApplyDeviceError(error);
         options?.callbacks?.onDeviceError?.(error);
         this.emit(RTVIEvent.DeviceError, error);
       },
@@ -412,11 +459,94 @@ export class PipecatClient extends RTVIEventEmitter {
   // ------ Transport methods
 
   /**
-   * Initialize local media devices
+   * Initialize local media devices.
+   *
+   * Drives MediaState transitions: both mic and cam move to 'initializing' on
+   * entry. On success, each device moves to 'granted' only if the transport
+   * reports it as acquired (via onMicUpdated / onCamUpdated with a real
+   * deviceId); otherwise that device falls back to 'uninitialized'. On
+   * failure the in-flight DeviceError (if any) classifies the affected
+   * device(s) per-device; anything still at 'initializing' falls back to
+   * 'unknown'. The original error is always re-thrown.
+   *
+   * Calling this again after a failure is the recovery path — a second call
+   * re-enters 'initializing' and reclassifies. There is no separate
+   * retryDevices() method.
    */
   public async initDevices() {
     logger.debug("[Pipecat Client] Initializing devices...");
-    await this._transport.initDevices();
+    // Both devices enter the lifecycle, regardless of enableMic / enableCam.
+    // The actual transport behavior is asymmetric and not predictable from
+    // options alone (e.g. daily-js's startCamera honors startVideoOff but not
+    // startAudioOff — it acquires the mic even when the caller said
+    // enableMic: false). MediaState mirrors what the transport actually did,
+    // sourced from onMicUpdated / onCamUpdated events that fire with a real
+    // deviceId only when permission was granted. Devices the transport never
+    // speaks to fall back to 'uninitialized' below.
+    this._setMediaState({
+      mic: { state: "initializing" },
+      cam: { state: "initializing" },
+    });
+
+    try {
+      await this._transport.initDevices();
+      // Transport resolved. Per-device transitions during the await:
+      //   - onMicUpdated / onCamUpdated upgraded reported devices to 'granted'
+      //   - onDeviceError applied per-device 'error' classifications
+      // Anything still at 'initializing' wasn't reported either way — the
+      // transport simply didn't speak to that device (e.g. daily-js skipping
+      // cam under startVideoOff: true). Fall it back to 'uninitialized'.
+      this._resolveLingeringInitializing({ state: "uninitialized" });
+    } catch (error) {
+      // Transport rejected. Same as above but the fallback for unspoken-to
+      // devices is 'unknown' — something failed and we can't tell whether
+      // this device would have worked.
+      this._resolveLingeringInitializing({
+        state: "error",
+        reason: "unknown",
+      });
+      throw error;
+    } finally {
+      // Re-query the Permissions API now that the prompt (if any) has been
+      // dismissed. Authoritative source for 'denied' regardless of what the
+      // transport said. See the helper for the under-reporting rationale.
+      await this._enrichFromPermissionsAPI();
+    }
+  }
+
+  /**
+   * After the transport's initDevices() resolves or rejects, any device
+   * still at 'initializing' didn't receive a 'granted' upgrade from
+   * onMicUpdated / onCamUpdated and wasn't classified by a DeviceError
+   * (which would have moved it to 'error'). Apply the supplied fallback so
+   * it doesn't linger.
+   *
+   * On success, fallback is 'uninitialized' (the transport simply didn't
+   * speak to that device — e.g. daily-js skipping cam under
+   * startVideoOff: true). On failure, fallback is an 'unknown' error (we
+   * know something went wrong but can't pin it on this device).
+   */
+  private _resolveLingeringInitializing(fallback: DeviceStatus): void {
+    const patch: Partial<MediaState> = {};
+    for (const kind of ["mic", "cam"] as const) {
+      if (this._mediaState[kind].state === "initializing") {
+        patch[kind] = fallback;
+      }
+    }
+    if (Object.keys(patch).length > 0) this._setMediaState(patch);
+  }
+
+  /**
+   * Upgrade a device to 'granted'. Called from the wrapped onMicUpdated /
+   * onCamUpdated when the transport reports an actual selected device.
+   * Allowed from any state — a previously errored device (e.g. 'not-found'
+   * because the cam was unplugged) can recover when the device reappears
+   * on a subsequent initDevices() call.
+   */
+  private _markDeviceGranted(kind: "mic" | "cam"): void {
+    if (this._mediaState[kind].state !== "granted") {
+      this._setMediaState({ [kind]: { state: "granted" } });
+    }
   }
 
   /**
@@ -427,8 +557,12 @@ export class PipecatClient extends RTVIEventEmitter {
    */
   @transportAlreadyStarted
   public async startBot(startBotParams: APIRequest): Promise<unknown> {
-    if (this._transport.state === "disconnected") {
-      await this._transport.initDevices();
+    // Implicit init when devices haven't been initialized yet. Pre-Plan-A
+    // this gate read transport.state === "disconnected", which fired both
+    // pre-init AND post-session — leading to redundant initDevices() calls
+    // on reconnect. needsInit(mediaState) is the unambiguous replacement.
+    if (this.needsInit()) {
+      await this.initDevices();
     }
     this._transport.state = "authenticating";
     this._transport.startBotParams = startBotParams;
@@ -487,8 +621,8 @@ export class PipecatClient extends RTVIEventEmitter {
       (async () => {
         this._connectResolve = resolve;
 
-        if (this._transport.state === "disconnected") {
-          await this._transport.initDevices();
+        if (this.needsInit()) {
+          await this.initDevices();
         }
 
         try {
@@ -536,6 +670,103 @@ export class PipecatClient extends RTVIEventEmitter {
   }
 
   /**
+   * Apply a partial MediaState patch and emit MediaStateUpdated if the patch
+   * actually changes anything. The callback always receives a fresh object.
+   */
+  private _setMediaState(patch: Partial<MediaState>): void {
+    const next: MediaState = { ...this._mediaState, ...patch };
+    if (
+      this._statusEquals(next.mic, this._mediaState.mic) &&
+      this._statusEquals(next.cam, this._mediaState.cam)
+    ) {
+      return;
+    }
+    this._mediaState = next;
+    this._options.callbacks?.onMediaStateChanged?.(this.mediaState);
+    this.emit(RTVIEvent.MediaStateUpdated, this.mediaState);
+  }
+
+  /**
+   * Structural equality for two DeviceStatus values. Distinct error
+   * statuses (different `reason` or `details`) are treated as distinct so a
+   * status update fires when the underlying error changes, even if `state`
+   * was already 'error'.
+   */
+  private _statusEquals(a: DeviceStatus, b: DeviceStatus): boolean {
+    if (a.state !== b.state) return false;
+    if (a.state === "error" && b.state === "error") {
+      return a.reason === b.reason && a.details === b.details;
+    }
+    return true;
+  }
+
+  /**
+   * Map a DeviceError onto a partial MediaState patch and apply it. Mirrors
+   * daily-react's camera-error classifier — affected devices flip to an
+   * `'error'` status carrying the reason and the original error payload.
+   */
+  private _classifyAndApplyDeviceError(error: RTVIErrors.DeviceError): void {
+    const status: DeviceStatus = {
+      state: "error",
+      reason: deviceErrorReasonFromType(error.type),
+      details: error.details,
+    };
+    const patch: Partial<MediaState> = {};
+    if (error.devices.includes("mic")) patch.mic = status;
+    if (error.devices.includes("cam")) patch.cam = status;
+    if (Object.keys(patch).length === 0) return; // speaker-only or empty
+    this._setMediaState(patch);
+  }
+
+  /**
+   * Permissions API enrichment, run AFTER the transport's initDevices()
+   * resolves. By that point the prompt (if any) has been dismissed, and the
+   * Permissions API's `denied` answer is authoritative — it overrides any
+   * under-reported DeviceError.
+   *
+   * Concrete case worth flagging: on a page where the user previously
+   * blocked permissions, daily-js's `camera-error` only names whichever
+   * device the transport tried first when re-initializing — even though
+   * both are blocked. Re-querying here catches the missing one. Worth a
+   * follow-up daily-js ticket.
+   *
+   * Silently no-ops where the API is unavailable (Safari, some mobile
+   * browsers) or throws on an unsupported descriptor.
+   */
+  private async _enrichFromPermissionsAPI(): Promise<void> {
+    // PermissionDescriptor's `name` field isn't a standard enum across
+    // browsers (Safari historically narrower than Chrome/Firefox), and
+    // 'microphone' / 'camera' are not in lib.dom's PermissionName union in
+    // every TS version. Hand-roll the descriptor type and cast.
+    type PermDescriptor = { name: "microphone" | "camera" };
+    type Q = (descriptor: PermDescriptor) => Promise<{ state: string }>;
+    const permissions = (
+      globalThis as unknown as {
+        navigator?: { permissions?: { query: Q } };
+      }
+    ).navigator?.permissions;
+    if (!permissions?.query) return;
+    const query = permissions.query.bind(permissions);
+
+    const patch: Partial<MediaState> = {};
+    await Promise.all(
+      (["mic", "cam"] as const).map(async (kind) => {
+        try {
+          const result = await query({
+            name: kind === "mic" ? "microphone" : "camera",
+          });
+          if (result.state === "denied") {
+            patch[kind] = { state: "error", reason: "blocked" };
+          }
+        } catch {
+          // Browsers may throw on unsupported descriptor names — swallow.
+        }
+      })
+    );
+    if (Object.keys(patch).length > 0) this._setMediaState(patch);
+  }
+
+  /**
    * Internal wrapper around the transport's sendMessage method
    */
   private _sendMessage(message: RTVIMessage): void {
@@ -574,6 +805,48 @@ export class PipecatClient extends RTVIEventEmitter {
 
   public get state(): TransportState {
     return this._transport.state;
+  }
+
+  /**
+   * Per-device device state (mic, cam). Independent of transport state.
+   *
+   * Updated by initDevices() and DeviceError events. Returns a snapshot — to
+   * track changes, subscribe to RTVIEvent.MediaStateUpdated or pass an
+   * onMediaStateChanged callback in the client constructor.
+   */
+  public get mediaState(): MediaState {
+    // Deep snapshot — DeviceStatus is a nested object, so a shallow spread
+    // would still hand the caller a reference to our per-device records.
+    return {
+      mic: { ...this._mediaState.mic },
+      cam: { ...this._mediaState.cam },
+    };
+  }
+
+  /**
+   * Whether initDevices() still has work to do. Returns true if any device
+   * the caller opted into (enableMic / enableCam) is still 'uninitialized'.
+   * Devices the caller opted out of are not considered — they stay
+   * 'uninitialized' by design and must not gate the implicit init.
+   *
+   * Used internally by connect() / startBot() to decide whether to drive an
+   * implicit initDevices(); exposed publicly so consumers (e.g. step 3's
+   * useMediaState hook) can branch on the same logic.
+   */
+  public needsInit(): boolean {
+    if (
+      this._options.enableMic !== false &&
+      this._mediaState.mic.state === "uninitialized"
+    ) {
+      return true;
+    }
+    if (
+      this._options.enableCam !== false &&
+      this._mediaState.cam.state === "uninitialized"
+    ) {
+      return true;
+    }
+    return false;
   }
 
   public get version(): string {

--- a/client-js/rtvi/common_types.ts
+++ b/client-js/rtvi/common_types.ts
@@ -28,3 +28,58 @@ export type Participant = {
   name: string;
   local: boolean;
 };
+
+/**
+ * Per-device lifecycle state, tracked independently for the mic and the cam.
+ * Modelled after daily-react's DailyDevices. Transitions are driven by
+ * explicit calls to PipecatClient.initDevices() and by DeviceError events.
+ * Never by transport connect/disconnect.
+ */
+export type DeviceState =
+  /** initDevices() has not been called yet for this device */
+  | "uninitialized"
+  /** initDevices() is in flight (enumeration / permission request) */
+  | "initializing"
+  /** Device is enumerated and ready to use */
+  | "granted"
+  /** Device is in an error state and could not be acquired */
+  | "error";
+
+/**
+ * Per-device error categories. Only meaningful when DeviceStatus.state is
+ * 'error'. Mirrors the shape of DeviceErrorType but expressed in
+ * MediaState's own vocabulary so consumers can render UI without going
+ * through the underlying error object.
+ */
+export type DeviceErrorReason =
+  /** User explicitly denied permission */
+  | "blocked"
+  /** Hardware is busy in another application */
+  | "already-in-use"
+  /** No matching hardware was found */
+  | "not-found"
+  /** getUserMedia constraints couldn't be satisfied */
+  | "invalid-constraints"
+  /** Browser API is unavailable (legacy browser, insecure context) */
+  | "not-supported"
+  /** Catch-all for errors we couldn't classify */
+  | "unknown";
+
+/**
+ * Per-device status. A discriminated union: when `state` is `'error'`, the
+ * `reason` field describes the error category (and `details` may carry the
+ * raw error payload). Consumers branch on `state` to decide what to render.
+ */
+export type DeviceStatus =
+  | { state: "uninitialized" | "initializing" | "granted" }
+  | { state: "error"; reason: DeviceErrorReason; details?: unknown };
+
+/**
+ * Per-device state on PipecatClient, exposed independently of TransportState.
+ * Speakers are intentionally not tracked here: output devices have no
+ * permission or in-use failure mode, only enumeration.
+ */
+export type MediaState = {
+  mic: DeviceStatus;
+  cam: DeviceStatus;
+};

--- a/client-js/rtvi/events.ts
+++ b/client-js/rtvi/events.ts
@@ -4,7 +4,7 @@
  * SPDX-License-Identifier: BSD-2-Clause
  */
 
-import { Participant, TransportState } from "./common_types";
+import { MediaState, Participant, TransportState } from "./common_types";
 import { DeviceError } from "./errors";
 import {
   BotLLMSearchResponseData,
@@ -98,6 +98,7 @@ export enum RTVIEvent {
   MicUpdated = "micUpdated",
   SpeakerUpdated = "speakerUpdated",
   DeviceError = "deviceError",
+  MediaStateUpdated = "mediaStateUpdated",
 }
 
 export type RTVIEvents = Partial<{
@@ -178,6 +179,7 @@ export type RTVIEvents = Partial<{
   micUpdated: (mic: MediaDeviceInfo) => void;
   speakerUpdated: (speaker: MediaDeviceInfo) => void;
   deviceError: (error: DeviceError) => void;
+  mediaStateUpdated: (mediaState: MediaState) => void;
 }>;
 
 export type RTVIEventHandler<E extends RTVIEvent> = E extends keyof RTVIEvents

--- a/client-js/tests/initDevices.spec.ts
+++ b/client-js/tests/initDevices.spec.ts
@@ -46,7 +46,17 @@ class CharacterizationTransport extends TransportStub {
         setTimeout(() => reject(err), 10);
       });
     }
-    return super.initDevices();
+    // Mirror what a happy-path transport does: enumerate first, then notify.
+    // Events fire AFTER the underlying acquisition completes, before the
+    // promise settles, so PipecatClient sees them inside its await.
+    return super.initDevices().then(() => {
+      this._callbacks.onMicUpdated?.({
+        deviceId: "mic-default",
+      } as MediaDeviceInfo);
+      this._callbacks.onCamUpdated?.({
+        deviceId: "cam-default",
+      } as MediaDeviceInfo);
+    });
   }
 
   private forceState(next: TransportState): void {
@@ -145,19 +155,27 @@ describe("PipecatClient.initDevices() — characterization", () => {
     expect(client.state).toBe("ready");
   });
 
-  test("reconnect after disconnect re-runs initDevices() (state reverts to 'disconnected')", async () => {
+  test("reconnect after disconnect does NOT re-run initDevices() (mediaState gate)", async () => {
     await client.connect();
     await client.disconnect();
 
     expect(client.state).toBe("disconnected");
     expect(transport.initDevicesCallCount).toBe(1);
+    // The fake transport reports both devices acquired on init (mirroring
+    // what daily-js actually does, even when enableMic / enableCam disagree).
+    expect(client.mediaState).toEqual({
+      mic: { state: "granted" },
+      cam: { state: "granted" },
+    });
 
     await client.connect();
 
-    // Because disconnect() returns state to 'disconnected' — the same sentinel
-    // as the pre-init initial state — the implicit-init gate trips again.
-    // This is the downstream visible symptom behind the stuck-spinner bug.
-    expect(transport.initDevicesCallCount).toBe(2);
+    // Step 2 replaced the `state === "disconnected"` gate with
+    // needsInit(mediaState). Post-disconnect, mediaState is still
+    // {mic:"granted", cam:"granted"}, so the implicit-init no longer
+    // double-fires. Picker access survives the disconnect — this is the
+    // contract voice-ui-kit will rely on in step 4.
+    expect(transport.initDevicesCallCount).toBe(1);
     expect(client.state).toBe("ready");
   });
 

--- a/client-js/tests/mediaState.spec.ts
+++ b/client-js/tests/mediaState.spec.ts
@@ -1,0 +1,551 @@
+/**
+ * Copyright (c) 2026, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ *
+ * Tests for the MediaState surface added in Plan A step 2. Covers:
+ * - lifecycle transitions on initDevices() success / failure
+ * - DeviceError → DeviceStatus classification (per-device)
+ * - MediaStateUpdated event + onMediaStateChanged callback fan-out
+ * - needsInit gate behavior across connect/reconnect/post-failure paths
+ * - Permissions API enrichment (post-transport) with silent fallback
+ * - Devices the transport doesn't acquire (stay 'uninitialized')
+ */
+
+import { afterEach, beforeEach, describe, expect, jest, test } from "@jest/globals";
+
+import { PipecatClient } from "../client";
+import {
+  DeviceError,
+  DeviceErrorReason,
+  DeviceErrorType,
+  DeviceStatus,
+  MediaState,
+  RTVIEvent,
+} from "../rtvi";
+import { TransportStub } from "./stubs/transport";
+
+/**
+ * The transport-level signals MediaState observes per device. Setting either
+ * to a MediaDeviceInfo causes the corresponding onMicUpdated/onCamUpdated
+ * event to fire during initDevices() — which is how PipecatClient learns
+ * the transport actually acquired the device. Setting to undefined skips
+ * the event (the transport didn't speak to that device, e.g. daily-js
+ * skipping cam under startVideoOff: true).
+ */
+type FakeAcquired = { mic?: MediaDeviceInfo; cam?: MediaDeviceInfo };
+const DEFAULT_ACQUIRED: FakeAcquired = {
+  mic: { deviceId: "mic-default" } as MediaDeviceInfo,
+  cam: { deviceId: "cam-default" } as MediaDeviceInfo,
+};
+
+class MediaStateTransport extends TransportStub {
+  public initDevicesCallCount = 0;
+  public initDevicesShouldThrow: Error | undefined;
+  public emitDeviceErrorDuringInit: DeviceError | undefined;
+  public acquiredOnInit: FakeAcquired = { ...DEFAULT_ACQUIRED };
+
+  static override create(): MediaStateTransport {
+    return new MediaStateTransport();
+  }
+
+  public override initDevices(): Promise<void> {
+    this.initDevicesCallCount += 1;
+    // Real transports do their device acquisition first, then notify via
+    // onDeviceError / onMicUpdated / onCamUpdated, then resolve or reject.
+    // Mirror that ordering: fire events inside the super.initDevices()
+    // continuation, before settling.
+    return super.initDevices().then(() => {
+      if (this.emitDeviceErrorDuringInit) {
+        this._callbacks.onDeviceError?.(this.emitDeviceErrorDuringInit);
+      }
+      const errorDevices = this.emitDeviceErrorDuringInit?.devices ?? [];
+      if (this.acquiredOnInit.mic && !errorDevices.includes("mic")) {
+        this._callbacks.onMicUpdated?.(this.acquiredOnInit.mic);
+      }
+      if (this.acquiredOnInit.cam && !errorDevices.includes("cam")) {
+        this._callbacks.onCamUpdated?.(this.acquiredOnInit.cam);
+      }
+      if (this.initDevicesShouldThrow) {
+        throw this.initDevicesShouldThrow;
+      }
+    });
+  }
+
+  public emitDeviceError(error: DeviceError): void {
+    this._callbacks.onDeviceError?.(error);
+  }
+}
+
+const recordMediaState = (client: PipecatClient): MediaState[] => {
+  const states: MediaState[] = [];
+  client.on(RTVIEvent.MediaStateUpdated, (s) => states.push(s));
+  return states;
+};
+
+// Shorthand DeviceStatus values used heavily across assertions.
+const UNINIT: DeviceStatus = { state: "uninitialized" };
+const INITIALIZING: DeviceStatus = { state: "initializing" };
+const GRANTED: DeviceStatus = { state: "granted" };
+const errored = (
+  reason: DeviceErrorReason,
+  details?: unknown
+): DeviceStatus => ({ state: "error", reason, details });
+
+/**
+ * Most tests below want to exercise the full mic+cam lifecycle, so they
+ * opt both devices in explicitly. The PipecatClient default is enableMic:
+ * true, enableCam: false — passing it implicitly would leave cam at
+ * 'uninitialized' through the whole call (a separate code path tested in
+ * its own describe).
+ */
+const buildClient = (
+  transport: MediaStateTransport,
+  overrides: {
+    enableMic?: boolean;
+    enableCam?: boolean;
+    callbacks?: ConstructorParameters<typeof PipecatClient>[0]["callbacks"];
+  } = {}
+): PipecatClient =>
+  new PipecatClient({
+    transport,
+    enableMic: overrides.enableMic ?? true,
+    enableCam: overrides.enableCam ?? true,
+    callbacks: overrides.callbacks,
+  });
+
+describe("MediaState — lifecycle on initDevices()", () => {
+  let transport: MediaStateTransport;
+  let client: PipecatClient;
+
+  beforeEach(() => {
+    transport = MediaStateTransport.create();
+    client = buildClient(transport);
+  });
+
+  test("initial mediaState is uninitialized for both devices", () => {
+    expect(client.mediaState).toEqual({ mic: UNINIT, cam: UNINIT });
+  });
+
+  test("happy path: uninitialized → initializing → granted (per-device)", async () => {
+    const updates = recordMediaState(client);
+
+    await client.initDevices();
+
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+    // The stub fires onMicUpdated then onCamUpdated, so each device flips
+    // to 'granted' in turn rather than as a single batched update.
+    expect(updates).toEqual([
+      { mic: INITIALIZING, cam: INITIALIZING },
+      { mic: GRANTED, cam: INITIALIZING },
+      { mic: GRANTED, cam: GRANTED },
+    ]);
+  });
+
+  test("onMediaStateChanged callback fires alongside the event emitter", async () => {
+    const callbackSnapshots: MediaState[] = [];
+    const callbackTransport = MediaStateTransport.create();
+    const callbackClient = buildClient(callbackTransport, {
+      callbacks: {
+        onMediaStateChanged: (s) => callbackSnapshots.push(s),
+      },
+    });
+
+    await callbackClient.initDevices();
+
+    expect(callbackSnapshots).toEqual([
+      { mic: INITIALIZING, cam: INITIALIZING },
+      { mic: GRANTED, cam: INITIALIZING },
+      { mic: GRANTED, cam: GRANTED },
+    ]);
+  });
+
+  test("MediaState getter returns a deep snapshot", () => {
+    // Both top-level spread and per-device copy: mutating either layer of
+    // the snapshot must not bleed into the client's internal record.
+    const snapshot = client.mediaState;
+    snapshot.mic = errored("blocked");
+    (snapshot.cam as { state: string }).state = "granted";
+    expect(client.mediaState).toEqual({ mic: UNINIT, cam: UNINIT });
+  });
+});
+
+describe("MediaState — DeviceError classification", () => {
+  // (DeviceErrorType, expected DeviceErrorReason)
+  const cases: Array<[DeviceErrorType, DeviceErrorReason]> = [
+    ["in-use", "already-in-use"],
+    ["permissions", "blocked"],
+    ["not-found", "not-found"],
+    ["undefined-mediadevices", "not-supported"],
+    ["constraints", "invalid-constraints"],
+    ["unknown", "unknown"],
+  ];
+
+  test.each(cases)(
+    "DeviceError type '%s' classifies affected devices to error reason '%s'",
+    async (errorType, expectedReason) => {
+      const transport = MediaStateTransport.create();
+      const client = buildClient(transport);
+
+      transport.emitDeviceErrorDuringInit = new DeviceError(
+        ["mic", "cam"],
+        errorType
+      );
+      transport.initDevicesShouldThrow = new Error("init failed");
+
+      await expect(client.initDevices()).rejects.toThrow();
+
+      expect(client.mediaState).toEqual({
+        mic: errored(expectedReason),
+        cam: errored(expectedReason),
+      });
+    }
+  );
+
+  test("partial DeviceError mid-init: unaffected device resolves to 'granted' when transport succeeds", async () => {
+    // mediaManager fires DeviceError for mic only, then the overall
+    // transport.initDevices() resolves and the cam was acquired separately.
+    // Cam should reach 'granted' via its onCamUpdated event.
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    transport.emitDeviceErrorDuringInit = new DeviceError(
+      ["mic"],
+      "permissions"
+    );
+
+    await client.initDevices();
+
+    expect(client.mediaState).toEqual({
+      mic: errored("blocked"),
+      cam: GRANTED,
+    });
+  });
+
+  test("partial DeviceError + transport reject + nothing acquired: unaffected device falls back to 'unknown'", async () => {
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = {}; // model wholesale failure: nothing acquired
+    transport.emitDeviceErrorDuringInit = new DeviceError(
+      ["mic"],
+      "permissions"
+    );
+    transport.initDevicesShouldThrow = new Error("init failed");
+    const client = buildClient(transport);
+
+    await expect(client.initDevices()).rejects.toThrow();
+
+    expect(client.mediaState).toEqual({
+      mic: errored("blocked"),
+      cam: errored("unknown"),
+    });
+  });
+
+  test("DeviceError affecting only ['mic'] leaves cam in its prior status", async () => {
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    // Drive a happy init first so cam reaches 'granted', then fire a
+    // mic-only DeviceError out-of-band.
+    await client.initDevices();
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+
+    transport.emitDeviceError(new DeviceError(["mic"], "in-use"));
+
+    expect(client.mediaState).toEqual({
+      mic: errored("already-in-use"),
+      cam: GRANTED,
+    });
+  });
+
+  test("DeviceError affecting only ['speaker'] is a no-op for MediaState", async () => {
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    await client.initDevices();
+    transport.emitDeviceError(new DeviceError(["speaker"], "in-use"));
+
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+  });
+
+  test("recovering device: a previously errored device can transition back to 'granted'", async () => {
+    // E.g. cam was unplugged → 'not-found' → user plugs it in and re-inits
+    // → cam should upgrade to 'granted'. _markDeviceGranted does not gate
+    // on prior state.
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    // First init: cam reports as not-found.
+    transport.acquiredOnInit = { mic: { deviceId: "mic-1" } as MediaDeviceInfo };
+    transport.emitDeviceErrorDuringInit = new DeviceError(["cam"], "not-found");
+    await client.initDevices();
+    expect(client.mediaState).toEqual({
+      mic: GRANTED,
+      cam: errored("not-found"),
+    });
+
+    // Second init: cam now acquired.
+    transport.acquiredOnInit = { ...DEFAULT_ACQUIRED };
+    transport.emitDeviceErrorDuringInit = undefined;
+    await client.initDevices();
+
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+  });
+});
+
+describe("MediaState — needsInit() gate in connect()/startBot()", () => {
+  test("connect() drives implicit initDevices() when mediaState is uninitialized", async () => {
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    await client.connect();
+
+    expect(transport.initDevicesCallCount).toBe(1);
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+  });
+
+  test("reconnect after disconnect does NOT re-init (mediaState stays 'granted')", async () => {
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    await client.connect();
+    await client.disconnect();
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+
+    await client.connect();
+
+    // The new gate short-circuits — no second init triggered by reconnect.
+    expect(transport.initDevicesCallCount).toBe(1);
+  });
+
+  test("connect() after a failed initDevices() does NOT retry init (mediaState is in an error state)", async () => {
+    // After a rejection, mediaState lands in 'error'. needsInit only
+    // returns true when a requested device is 'uninitialized', so connect()
+    // does NOT trigger another implicit init. Recovery is the user's job:
+    // call initDevices() again explicitly.
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = {};
+    const client = buildClient(transport);
+
+    transport.initDevicesShouldThrow = new Error("first attempt failed");
+    await expect(client.initDevices()).rejects.toThrow();
+
+    transport.initDevicesShouldThrow = undefined;
+    transport.acquiredOnInit = { ...DEFAULT_ACQUIRED };
+    await client.connect();
+
+    // No implicit re-init from connect(). Only the original explicit call.
+    expect(transport.initDevicesCallCount).toBe(1);
+  });
+
+  test("client.needsInit() reflects the same gate logic", async () => {
+    // The gate is a public method so consumers (e.g. step 3's hooks) can
+    // branch on the same logic that drives the implicit init.
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    expect(client.needsInit()).toBe(true);
+
+    await client.initDevices();
+
+    expect(client.needsInit()).toBe(false);
+  });
+});
+
+describe("MediaState — Permissions API enrichment (post-transport)", () => {
+  type FakePermissionStatus = { state: "granted" | "denied" | "prompt" };
+  let originalPermissions: unknown;
+
+  const installFakePermissions = (
+    handler: (name: string) => Promise<FakePermissionStatus>
+  ): void => {
+    const nav = globalThis.navigator as unknown as { permissions: unknown };
+    originalPermissions = nav.permissions;
+    Object.defineProperty(nav, "permissions", {
+      configurable: true,
+      value: {
+        // The real navigator.permissions.query takes a PermissionDescriptor
+        // object — assert that here so we catch a bare-string regression.
+        query: jest.fn(async (descriptor: unknown) => {
+          if (
+            typeof descriptor !== "object" ||
+            descriptor === null ||
+            typeof (descriptor as { name?: unknown }).name !== "string"
+          ) {
+            throw new TypeError(
+              "permissions.query() expects a PermissionDescriptor"
+            );
+          }
+          return handler((descriptor as { name: string }).name);
+        }),
+      },
+    });
+  };
+
+  afterEach(() => {
+    const nav = globalThis.navigator as unknown as { permissions: unknown };
+    Object.defineProperty(nav, "permissions", {
+      configurable: true,
+      value: originalPermissions,
+    });
+  });
+
+  test("'denied' for microphone marks mic 'blocked' even when transport happy-paths", async () => {
+    installFakePermissions(async (name) => ({
+      state: name === "microphone" ? "denied" : "prompt",
+    }));
+
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    await client.initDevices();
+
+    // Permissions API runs after the transport call resolves and is
+    // authoritative for 'denied' regardless of what the transport reported.
+    expect(client.mediaState).toEqual({
+      mic: errored("blocked"),
+      cam: GRANTED,
+    });
+  });
+
+  test("missing navigator.permissions falls back silently", async () => {
+    const nav = globalThis.navigator as unknown as { permissions: unknown };
+    originalPermissions = nav.permissions;
+    Object.defineProperty(nav, "permissions", {
+      configurable: true,
+      value: undefined,
+    });
+
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    await expect(client.initDevices()).resolves.toBeUndefined();
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+  });
+
+  test("post-transport re-query overrides under-reported blocked devices", async () => {
+    // Real-world repro: page where permissions were previously blocked, no
+    // prompt is shown on subsequent inits. daily-js's `camera-error` only
+    // names whichever device the transport tried first, leaving the other
+    // appearing 'granted' in the DeviceError. The post-transport
+    // Permissions API call catches the missing one.
+    installFakePermissions(async () => ({ state: "denied" }));
+
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    // Transport reports cam-only block, then resolves successfully.
+    transport.emitDeviceErrorDuringInit = new DeviceError(
+      ["cam"],
+      "permissions"
+    );
+
+    await client.initDevices();
+
+    expect(client.mediaState).toEqual({
+      mic: errored("blocked"),
+      cam: errored("blocked"),
+    });
+  });
+
+  test("permissions.query() that throws does not break initDevices", async () => {
+    installFakePermissions(async () => {
+      throw new Error("PermissionName not supported");
+    });
+
+    const transport = MediaStateTransport.create();
+    const client = buildClient(transport);
+
+    await expect(client.initDevices()).resolves.toBeUndefined();
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: GRANTED });
+  });
+});
+
+describe("MediaState — devices the transport didn't acquire stay 'uninitialized'", () => {
+  // MediaState reflects what the transport actually did. A device that was
+  // never reported acquired (no onMicUpdated / onCamUpdated event with a
+  // real deviceId) stays at 'uninitialized'. This is independent of the
+  // user's enableMic / enableCam options — the underlying transport has the
+  // final say (e.g. daily-js's startCamera honors startVideoOff but not
+  // startAudioOff, so the asymmetry is visible to consumers either way).
+
+  test("transport that doesn't acquire cam leaves cam at 'uninitialized'", async () => {
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = { mic: { deviceId: "mic-1" } as MediaDeviceInfo };
+    const client = buildClient(transport);
+    const updates = recordMediaState(client);
+
+    await client.initDevices();
+
+    expect(client.mediaState).toEqual({ mic: GRANTED, cam: UNINIT });
+    expect(updates).toEqual([
+      { mic: INITIALIZING, cam: INITIALIZING },
+      { mic: GRANTED, cam: INITIALIZING },
+      // Post-await: cam was still 'initializing' so it falls back to
+      // 'uninitialized'.
+      { mic: GRANTED, cam: UNINIT },
+    ]);
+  });
+
+  test("transport that doesn't acquire mic leaves mic at 'uninitialized'", async () => {
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = { cam: { deviceId: "cam-1" } as MediaDeviceInfo };
+    const client = buildClient(transport);
+
+    await client.initDevices();
+
+    expect(client.mediaState).toEqual({ mic: UNINIT, cam: GRANTED });
+  });
+
+  test("partial DeviceError + non-acquired cam: cam stays 'uninitialized'", async () => {
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = {}; // neither acquired in this scenario
+    transport.emitDeviceErrorDuringInit = new DeviceError(
+      ["mic"],
+      "permissions"
+    );
+    const client = buildClient(transport);
+
+    await client.initDevices();
+
+    // Mic is classified from the DeviceError (blocked). Cam was never
+    // reported acquired and isn't in the error — falls back to 'uninitialized'.
+    expect(client.mediaState).toEqual({
+      mic: errored("blocked"),
+      cam: UNINIT,
+    });
+  });
+
+  test("transport rejection without acquisition events: both fall back to 'unknown'", async () => {
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = {};
+    transport.initDevicesShouldThrow = new Error("boom");
+    const client = buildClient(transport);
+
+    await expect(client.initDevices()).rejects.toThrow("boom");
+
+    expect(client.mediaState).toEqual({
+      mic: errored("unknown"),
+      cam: errored("unknown"),
+    });
+  });
+
+  test("needsInit gate: both opted out + no acquisition → no implicit init loop", async () => {
+    // If the user opts out of both devices and the transport respects that,
+    // mediaState stays at 'uninitialized'. needsInit must NOT keep firing
+    // on every connect() — that would loop forever.
+    const transport = MediaStateTransport.create();
+    transport.acquiredOnInit = {};
+    const client = buildClient(transport, {
+      enableMic: false,
+      enableCam: false,
+    });
+
+    await client.connect();
+    await client.disconnect();
+    await client.connect();
+
+    // needsInit considers only requested devices, so with both opted out it
+    // returns false and no implicit init is triggered.
+    expect(transport.initDevicesCallCount).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

Plan A step 2. Introduces a per-device `MediaState` (`mic`, `cam`) on `PipecatClient`, independent of `TransportState`. Resolves the `'disconnected'` sentinel ambiguity that step 1 characterized: consumers now have a separate, unambiguous signal for device readiness vs session state.

Modelled after [daily-react's DailyDevices](https://github.com/daily-co/daily-react/blob/main/src/DailyDevices.tsx). All additive, minor-version. No breaking changes.

Context: [Pipecat: Fixing the Device Picker Spinner After Disconnect](https://www.notion.so/dailyco/Pipecat-Fixing-the-Device-Picker-Spinner-After-Disconnect-3488fc5824d0810cb7ced697f3956ee6).

## New API surface

- `DeviceState` union: `"uninitialized" | "initializing" | "granted" | "error"`.
- `DeviceErrorReason` union: `"blocked" | "already-in-use" | "not-found" | "invalid-constraints" | "not-supported" | "unknown"`.
- `DeviceStatus` discriminated union: `{ state: 'uninitialized' | 'initializing' | 'granted' }` or `{ state: 'error', reason: DeviceErrorReason, details?: unknown }`. Consumers branch on `state` and TS narrows; error info no longer requires checking against an exclusion list of "non-error" strings.
- `MediaState` type: `{ mic: DeviceStatus, cam: DeviceStatus }` (speakers intentionally excluded — no permission/in-use mode).
- `RTVIEvent.MediaStateUpdated` event.
- `onMediaStateChanged` callback in `RTVIEventCallbacks`.
- `client.mediaState` getter (returns a deep snapshot).
- `client.needsInit()` public method — same logic that drives the implicit-init gate, exposed for consumers (e.g. step 3's hooks) to branch on.

## Behavior

- `initDevices()` drives both devices into `'initializing'` on entry. Per-device `'granted'` transitions are sourced from `onMicUpdated` / `onCamUpdated` events the transport fires with a real `deviceId`. **MediaState mirrors what the transport actually did, not what the caller asked for** — necessary because real transports are asymmetric (e.g. daily-js's `startCamera` honors `startVideoOff` but acquires the mic regardless of `startAudioOff`).
- Devices the transport never reports acquired fall back to `'uninitialized'` on success, `{ state: 'error', reason: 'unknown' }` on failure.
- `DeviceError` events update MediaState per-device via a daily-react-style classifier. Speaker-only errors are no-ops for MediaState. Devices in error states (e.g. `not-found` because the cam was unplugged) can recover to `'granted'` on a subsequent `initDevices()` call when the device becomes available again.
- The implicit-init gate in `connect()` and `startBot()` is now `needsInit()` instead of `state === 'disconnected'`. **Reconnect no longer double-fires `initDevices()`**, and pickers stay accessible after a disconnect (the contract step 4 voice-ui-kit will rely on). The gate considers only opted-in devices, so callers who set both `enableMic` and `enableCam` to `false` don't hit a redundant init loop.
- **Permissions API enrichment runs post-transport.** A `'denied'` answer from `navigator.permissions.query({ name })` authoritatively flips the device to `{ state: 'error', reason: 'blocked' }`, overriding any under-reported `DeviceError` from the transport (concrete case: on a page where permissions were previously blocked, daily-js's `camera-error` only names whichever device was tried first — the post-transport re-query catches the missing one). Silent fallback when the API is unavailable or throws (Safari, mobile browsers). Worth a daily-js follow-up ticket.

## Decisions locked in

These were deferred in the design doc; resolved here so step 3 / step 4 don't re-litigate:

1. **Permissions enrichment is post-transport only** and authoritative for `'denied'`. Pre-transport enrichment was dropped — the timing benefit is imperceptible vs the post-transport flip.
2. **Pre-session auto-trigger stays opt-in.** `PipecatClient` does not auto-call `initDevices()`. The current behavior (explicit `initDevices()`, or implicit via `connect()` / `startBot()`) is preserved. Step 3's state provider will expose a prop for consumers that want auto-init on mount, defaulting off.
3. **Transport idempotency handled at the client layer** via `needsInit`. No transport changes required. Plan B3 can revisit at the transport level later.
4. **Recovery is `initDevices()` itself.** A second call re-enters `'initializing'` and reclassifies. Per-device upgrades to `'granted'` are not gated on prior state — a previously errored device can recover when conditions change. No separate `retryDevices()` method.
5. **`enableMic` / `enableCam` are hints to the transport, not drivers of MediaState.** Underlying transports may acquire devices the caller didn't opt into (or skip ones they did). The user-visible state always reflects what's actually happening rather than what was requested.

## Tests

- `tests/mediaState.spec.ts` (29 tests): lifecycle, classification matrix (one test per `DeviceErrorType` mapped to its `DeviceErrorReason`), partial-error scenarios, recovery from error states, `needsInit` gate (including the public method exposure), Permissions API enrichment, and "transport didn't acquire" cases. Uses `UNINIT` / `INITIALIZING` / `GRANTED` / `errored(reason)` shorthand for readability.
- Step-1 reconnect test updated to assert the new no-double-init behavior and check `mediaState` directly. Both test stubs (`MediaStateTransport`, `CharacterizationTransport`) fire `onMicUpdated` / `onCamUpdated` after `super.initDevices()` resolves, mirroring real transport timing.
- Full suite: **110 / 110 pass**.

## Test plan

- [x] `npx jest` — 110 / 110 pass
- [x] `npx tsc --noEmit` — clean
- [x] `npx eslint client/ rtvi/ tests/` — clean
- [x] Hand-tested in a Vite playground against `SmallWebRTCTransport` across the four `enableMic`/`enableCam` combinations and several permission-block paths. Playground intentionally not committed.