### PR TITLE
feat(react): add useMediaState hook + autoInitDevices opt-in

### DIFF
--- a/client-react/src/PipecatClientMediaState.tsx
+++ b/client-react/src/PipecatClientMediaState.tsx
@@ -1,0 +1,78 @@
+/**
+ * Copyright (c) 2026, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+import { MediaState, RTVIEvent } from "@pipecat-ai/client-js";
+import { atom, useAtomValue } from "jotai";
+import { useAtomCallback } from "jotai/utils";
+import React, { useCallback, useEffect } from "react";
+
+import { usePipecatClient } from "./usePipecatClient";
+import { useRTVIClientEvent } from "./useRTVIClientEvent";
+
+const DEFAULT_MEDIA_STATE: MediaState = {
+  mic: { state: "uninitialized" },
+  cam: { state: "uninitialized" },
+};
+
+/**
+ * Module-scoped jotai atom holding the current per-device MediaState.
+ * Owned by PipecatClientMediaStateProvider — that's the single point that
+ * seeds it from `client.mediaState` and writes to it on every
+ * RTVIEvent.MediaStateUpdated. Hooks (useMediaState,
+ * usePipecatClientMediaDevices) only read.
+ */
+const mediaStateAtom = atom<MediaState>(DEFAULT_MEDIA_STATE);
+
+/**
+ * Provider that mirrors the underlying PipecatClient's MediaState into the
+ * shared jotai atom. Rendered automatically by PipecatClientProvider; not
+ * exported, so apps don't need to wire it up themselves.
+ *
+ * Centralizing the subscription here means consumer hooks stay thin — they
+ * just read the atom, with no per-hook seed effect — and a hook that mounts
+ * after initDevices() has run still sees the current state immediately.
+ */
+export const PipecatClientMediaStateProvider: React.FC<
+  React.PropsWithChildren
+> = ({ children }) => {
+  const client = usePipecatClient();
+
+  const setMediaState = useAtomCallback(
+    useCallback((_get, set, state: MediaState) => {
+      set(mediaStateAtom, state);
+    }, [])
+  );
+
+  // Seed from the current client snapshot. Covers the late-mount case
+  // (useMediaState consumers that mount after MediaStateUpdated has already
+  // fired) and the client-swap case (e.g. an app rebuilding its
+  // PipecatClient with new options).
+  useEffect(() => {
+    setMediaState(client?.mediaState ?? DEFAULT_MEDIA_STATE);
+  }, [client, setMediaState]);
+
+  useRTVIClientEvent(
+    RTVIEvent.MediaStateUpdated,
+    useCallback(
+      (next: MediaState) => {
+        setMediaState(next);
+      },
+      [setMediaState]
+    )
+  );
+
+  return <>{children}</>;
+};
+
+/**
+ * Subscribe to the per-device MediaState reported by the underlying
+ * PipecatClient. Returns a snapshot that re-renders the consumer whenever
+ * mic or cam transitions.
+ *
+ * Safe to call from any component rendered inside PipecatClientProvider —
+ * the subscription is owned by PipecatClientMediaStateProvider, which is
+ * mounted automatically.
+ */
+export const useMediaState = (): MediaState => useAtomValue(mediaStateAtom);

--- a/client-react/src/PipecatClientProvider.tsx
+++ b/client-react/src/PipecatClientProvider.tsx
@@ -19,12 +19,23 @@ import {
   version as packageVersion,
 } from "../package.json";
 import { PipecatConversationProvider } from "./conversation/PipecatConversationProvider";
+import { PipecatClientMediaStateProvider } from "./PipecatClientMediaState";
 import { PipecatClientStateProvider } from "./PipecatClientState";
 import { RTVIEventContext } from "./RTVIEventContext";
 
 export interface Props {
   client: PipecatClient;
   jotaiStore?: React.ComponentProps<typeof JotaiProvider>["store"];
+  /**
+   * Call `client.initDevices()` automatically when the provider mounts, if
+   * the client still needs init (i.e. no device has reached 'granted' yet).
+   *
+   * Defaults to `false` to preserve the safe behavior of not requesting
+   * device permissions before the user takes a deliberate action. Apps that
+   * already gathered consent (e.g. via signup flow, or a "join" button that
+   * itself triggers initDevices) can opt in by setting this to `true`.
+   */
+  autoInitDevices?: boolean;
 }
 
 const defaultStore = createStore();
@@ -39,13 +50,27 @@ type EventHandlersMap = {
 
 export const PipecatClientProvider: React.FC<
   React.PropsWithChildren<Props>
-> = ({ children, client, jotaiStore = defaultStore }) => {
+> = ({ children, client, jotaiStore = defaultStore, autoInitDevices = false }) => {
   useEffect(() => {
     setAboutClient({
       library: packageName,
       library_version: packageVersion,
     });
   }, []);
+
+  // Opt-in auto-init. Skip if the client has already initialized — covers
+  // hot-reload and provider remounts. Errors propagate via the client's
+  // own DeviceError event / MediaState classifier; we don't surface them
+  // here.
+  useEffect(() => {
+    if (!autoInitDevices || !client) return;
+    if (!client.needsInit()) return;
+    void client.initDevices().catch(() => {
+      // Intentionally swallowed — consumers observe failures via
+      // RTVIEvent.DeviceError, RTVIEvent.MediaStateUpdated, or the client's
+      // mediaState getter.
+    });
+  }, [autoInitDevices, client]);
 
   const eventHandlersMap = useRef<EventHandlersMap>({});
 
@@ -118,9 +143,11 @@ export const PipecatClientProvider: React.FC<
       <PipecatClientContext.Provider value={{ client }}>
         <RTVIEventContext.Provider value={{ on, off }}>
           <PipecatClientStateProvider>
-            <PipecatConversationProvider>
-              {children}
-            </PipecatConversationProvider>
+            <PipecatClientMediaStateProvider>
+              <PipecatConversationProvider>
+                {children}
+              </PipecatConversationProvider>
+            </PipecatClientMediaStateProvider>
           </PipecatClientStateProvider>
         </RTVIEventContext.Provider>
       </PipecatClientContext.Provider>

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -15,6 +15,7 @@ import { filterBotOutputText } from "./conversation/filterBotOutputText";
 import { useConversationContext } from "./conversation/PipecatConversationProvider";
 import { PipecatClientAudio } from "./PipecatClientAudio";
 import { PipecatClientCamToggle } from "./PipecatClientCamToggle";
+import { useMediaState } from "./PipecatClientMediaState";
 import { PipecatClientMicToggle } from "./PipecatClientMicToggle";
 import { PipecatClientProvider } from "./PipecatClientProvider";
 import { PipecatClientScreenShareToggle } from "./PipecatClientScreenShareToggle";
@@ -45,6 +46,7 @@ export {
   sortByCreatedAt,
   // Conversation
   useConversationContext,
+  useMediaState,
   usePipecatClient,
   usePipecatClientCamControl,
   usePipecatClientMediaDevices,


### PR DESCRIPTION
## Summary

Plan A step 3. Builds on the `MediaState` surface added in client-js 1.8.0 (#204) to give React consumers a per-device device-state hook and the opt-in auto-init contract that step 2 deferred here.

All additive. Existing hook return shapes unchanged.

Context: [Pipecat: Fixing the Device Picker Spinner After Disconnect](https://www.notion.so/dailyco/Pipecat-Fixing-the-Device-Picker-Spinner-After-Disconnect-3488fc5824d0810cb7ced697f3956ee6).

## Architecture: centralized state ownership

A new `PipecatClientMediaStateProvider` (internal, rendered automatically by `PipecatClientProvider`) owns the jotai atom that mirrors `client.mediaState`. It:

- **Seeds** the atom from `client.mediaState` on mount and on client changes.
- **Subscribes** to `RTVIEvent.MediaStateUpdated` and writes incoming payloads into the atom.

`useMediaState` only reads from the atom — no per-hook `useEffect`, no per-hook seed. A hook that mounts after the events have already fired (e.g. a settings page navigated to mid-session) sees the current state immediately because the provider has been keeping the atom in sync the whole time.

This matches the existing `PipecatClientStateProvider` pattern (rendered internally by `PipecatClientProvider`, not exported) at the cost of one extra nesting layer in the component tree.

## New API

### `useMediaState()`

```ts
const { mic, cam } = useMediaState();
// mic.state: 'uninitialized' | 'initializing' | 'granted' | 'error'
// when state === 'error': mic.reason: 'blocked' | 'already-in-use' | ...
```

### `autoInitDevices` on `PipecatClientProvider`

```tsx
<PipecatClientProvider client={client} autoInitDevices>
  ...
</PipecatClientProvider>
```

When `true`, the provider calls `client.initDevices()` on mount if `client.needsInit()` returns true. **Defaults to `false`** to preserve the safe "no preemptive permission prompts" behavior — matches the [step 2 decision](https://github.com/pipecat-ai/pipecat-client-web/pull/204) we locked in. Apps that already gathered consent (e.g. via signup or a "join" button) opt in; everyone else keeps today's behavior.

Errors during auto-init are intentionally swallowed at the provider — consumers observe failures via `RTVIEvent.DeviceError`, `RTVIEvent.MediaStateUpdated`, or by reading `client.mediaState` / `useMediaState()`.

## Notes on what's _not_ in this PR

The Notion plan also called for an `isReady` convenience on `usePipecatClientMediaDevices()`. **Dropped:** the meaning of "ready" is app-specific — a voice-only app considers itself ready when mic is `granted`, a voice+video app needs both, an app where cam is optional has its own definition. The core library should return technical truth via `useMediaState()`; consumers compute their own readiness predicate. Examples:

```ts
// Voice-only
const isReady = mic.state === "granted";

// Voice + video
const isReady = mic.state === "granted" && cam.state === "granted";

// Voice + optional video
const isReady = mic.state === "granted";
const hasVideo = cam.state === "granted";
```

## Tests

No new tests in this PR. Hooks in `client-react/src/` have no existing tests today (`usePipecatClientMediaDevices`, `usePipecatClientCamControl`, etc.). Adding hook-test infrastructure (`@testing-library/react` + a provider harness) is a meaningful infra investment that should be its own PR. The new code is a thin wrapper around well-tested machinery in client-js (#204 added 110 tests covering MediaState semantics).

Manual smoke-tested against `SmallWebRTCTransport` in a Vite playground covering:
- `useMediaState()` reflects per-device transitions live.
- A consumer that mounts after `initDevices()` already ran sees the current state immediately (the central seed in the new provider).
- `autoInitDevices={true}` triggers `initDevices()` on mount; `false` does not.
- Idempotency: remounting the provider with `autoInitDevices={true}` doesn't re-trigger when devices are already granted (`needsInit()` short-circuits).

## Test plan

- [x] `npx tsc --noEmit -p client-react` — clean
- [x] `npx eslint client-react/src/` — clean (the 700+ workspace-level errors are pre-existing test-file `no-undef` issues unrelated to this change)
- [x] `npx jest -w @pipecat-ai/client-react` — 185 / 185 pass (no new tests; existing suite still green)
- [x] Manual verification per the list above

## Step 4 hand-off

The contract `voice-ui-kit`'s `UserAudioControl` / `UserVideoControl` will use:

- Hide spinner / show picker when the relevant device is `state: 'granted'`.
- Show a "permission denied" affordance when `state: 'error', reason: 'blocked'`.
- Show "no hardware" / "device busy" / etc. for the remaining error reasons.
- Keep the picker accessible across `connect` / `disconnect` cycles — `mediaState` no longer regresses to `uninitialized` post-session.