### PR TITLE
fix(js): refresh snapshot when native form controls change

### DIFF
--- a/client-js/client/A11ySnapshotStreamer.ts
+++ b/client-js/client/A11ySnapshotStreamer.ts
@@ -79,6 +79,7 @@ export class A11ySnapshotStreamer {
   private resizeHandler?: () => void;
   private visibilityHandler?: () => void;
   private selectionHandler?: () => void;
+  private formHandler?: () => void;
 
   constructor(
     emitSnapshot: A11ySnapshotEmitter,
@@ -158,6 +159,17 @@ export class A11ySnapshotStreamer {
     // selection alongside the rest of the screen state.
     this.selectionHandler = () => this.schedule();
     document.addEventListener("selectionchange", this.selectionHandler);
+
+    // Native form controls (checkbox/radio toggles, text and select edits)
+    // change via element PROPERTIES, which a MutationObserver can't see - the
+    // attributeFilter above only catches them when an app mirrors state into
+    // aria-*. Listen for `input`/`change` in the capture phase so a user edit
+    // (or a programmatic change that dispatches these events) refreshes the
+    // snapshot. Debounced via `schedule`, so a burst of typing coalesces into
+    // a single snapshot at rest.
+    this.formHandler = () => this.schedule();
+    document.addEventListener("input", this.formHandler, { capture: true });
+    document.addEventListener("change", this.formHandler, { capture: true });
   }
 
   /** Stop streaming. Safe to call before `start()` or multiple times. */
@@ -184,6 +196,14 @@ export class A11ySnapshotStreamer {
       if (this.selectionHandler) {
         document.removeEventListener("selectionchange", this.selectionHandler);
       }
+      if (this.formHandler) {
+        document.removeEventListener("input", this.formHandler, {
+          capture: true,
+        });
+        document.removeEventListener("change", this.formHandler, {
+          capture: true,
+        });
+      }
     }
     if (typeof window !== "undefined") {
       if (this.scrollEndHandler) {
@@ -200,6 +220,7 @@ export class A11ySnapshotStreamer {
     this.resizeHandler = undefined;
     this.visibilityHandler = undefined;
     this.selectionHandler = undefined;
+    this.formHandler = undefined;
   }
 
   private schedule(): void {

--- a/client-js/tests/A11ySnapshotStreamer.spec.ts
+++ b/client-js/tests/A11ySnapshotStreamer.spec.ts
@@ -125,6 +125,53 @@ describe("A11ySnapshotStreamer", () => {
     expect(emissions).toHaveLength(3);
   });
 
+  it("emits when a form control fires input or change", () => {
+    document.body.innerHTML =
+      '<main><input type="checkbox" aria-label="Milk" /></main>';
+    const emissions: Emission[] = [];
+    const streamer = new A11ySnapshotStreamer((snapshot) => {
+      emissions.push(snapshot);
+    }, {
+      debounceMs: 100,
+    });
+    streamer.start();
+    jest.advanceTimersByTime(100);
+    expect(emissions).toHaveLength(1);
+
+    // A checkbox toggle changes the .checked PROPERTY (no DOM mutation),
+    // so the snapshot only refreshes because we listen for `change`.
+    const checkbox = document.querySelector("input")!;
+    checkbox.checked = true;
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    jest.advanceTimersByTime(100);
+    expect(emissions).toHaveLength(2);
+
+    // Typing fires `input`.
+    checkbox.dispatchEvent(new Event("input", { bubbles: true }));
+    jest.advanceTimersByTime(100);
+    expect(emissions).toHaveLength(3);
+
+    streamer.stop();
+  });
+
+  it("stops listening for form events after stop()", () => {
+    document.body.innerHTML =
+      '<main><input type="checkbox" aria-label="Milk" /></main>';
+    const emissions: Emission[] = [];
+    const streamer = new A11ySnapshotStreamer((snapshot) => {
+      emissions.push(snapshot);
+    }, {
+      debounceMs: 100,
+    });
+    const checkbox = document.querySelector("input")!;
+    streamer.start();
+    streamer.stop();
+
+    checkbox.dispatchEvent(new Event("change", { bubbles: true }));
+    jest.advanceTimersByTime(100);
+    expect(emissions).toHaveLength(0);
+  });
+
   it("logs snapshots when enabled", () => {
     const emissions: Emission[] = [];
     const groupCollapsed = jest


### PR DESCRIPTION
## What

`A11ySnapshotStreamer` re-captures on DOM mutations, focus, scroll-end,
resize, visibility, and selection changes — but **not** on native
form-control state changes. A checkbox/radio toggle, text input, or
`<select>` change the element's **property** (`.checked` / `.value`),
which a `MutationObserver` can't observe, and the `attributeFilter` only
catches them when an app mirrors state into `aria-*`. So checking a box or
typing into a field leaves the streamed snapshot stale, and an agent
reading it sees outdated UI state.

## Fix

Listen for `input` and `change` (capture phase, debounced through the
existing `schedule()`), with matching teardown in `stop()`. This covers
user edits **and** programmatic changes that dispatch these events. The
walker already reads native `.value`/`.checked` on capture, so no walker
change is needed.

## Testing

- Added two `A11ySnapshotStreamer` specs: *"emits when a form control
  fires input or change"* and *"stops listening for form events after
  `stop()`"*.
- Full `client-js` suite passes (181 tests); eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
