### PR TITLE
New callback for handling unsupported features

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -898,7 +898,6 @@ export class PipecatClient extends RTVIEventEmitter {
     } catch (e) {
       if (e instanceof RTVIErrors.UnsupportedFeatureError) {
         this._options.callbacks?.onUnsupportedFeature?.(e);
-        this.emit(RTVIEvent.UnsupportedFeature, e);
         return {};
       }
       throw e;
@@ -935,7 +934,6 @@ export class PipecatClient extends RTVIEventEmitter {
     } catch (e) {
       if (e instanceof RTVIErrors.UnsupportedFeatureError) {
         this._options.callbacks?.onUnsupportedFeature?.(e);
-        this.emit(RTVIEvent.UnsupportedFeature, e);
       } else {
         throw e;
       }
@@ -956,7 +954,6 @@ export class PipecatClient extends RTVIEventEmitter {
     } catch (e) {
       if (e instanceof RTVIErrors.UnsupportedFeatureError) {
         this._options.callbacks?.onUnsupportedFeature?.(e);
-        this.emit(RTVIEvent.UnsupportedFeature, e);
       } else {
         throw e;
       }

--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -139,6 +139,7 @@ export type RTVIEventCallbacks = Partial<{
     participant?: Participant
   ) => void;
   onScreenShareError: (errorMessage: string) => void;
+  onUnsupportedFeature: (error: RTVIErrors.UnsupportedFeatureError) => void;
   onLocalAudioLevel: (level: number) => void;
   onRemoteAudioLevel: (level: number, participant: Participant) => void;
 
@@ -313,6 +314,10 @@ export class PipecatClient extends RTVIEventEmitter {
       onScreenShareError: (errorMessage) => {
         options?.callbacks?.onScreenShareError?.(errorMessage);
         this.emit(RTVIEvent.ScreenShareError, errorMessage);
+      },
+      onUnsupportedFeature: (error) => {
+        options?.callbacks?.onUnsupportedFeature?.(error);
+        this.emit(RTVIEvent.UnsupportedFeature, error);
       },
       onAvailableCamsUpdated: (cams) => {
         options?.callbacks?.onAvailableCamsUpdated?.(cams);
@@ -888,7 +893,16 @@ export class PipecatClient extends RTVIEventEmitter {
   }
 
   public get selectedCam() {
-    return this._transport.selectedCam;
+    try {
+      return this._transport.selectedCam;
+    } catch (e) {
+      if (e instanceof RTVIErrors.UnsupportedFeatureError) {
+        this._options.callbacks?.onUnsupportedFeature?.(e);
+        this.emit(RTVIEvent.UnsupportedFeature, e);
+        return {};
+      }
+      throw e;
+    }
   }
 
   public get selectedSpeaker() {
@@ -916,7 +930,16 @@ export class PipecatClient extends RTVIEventEmitter {
   }
 
   public enableCam(enable: boolean) {
-    this._transport.enableCam(enable);
+    try {
+      this._transport.enableCam(enable);
+    } catch (e) {
+      if (e instanceof RTVIErrors.UnsupportedFeatureError) {
+        this._options.callbacks?.onUnsupportedFeature?.(e);
+        this.emit(RTVIEvent.UnsupportedFeature, e);
+      } else {
+        throw e;
+      }
+    }
   }
 
   public get isCamEnabled(): boolean {
@@ -928,7 +951,16 @@ export class PipecatClient extends RTVIEventEmitter {
   }
 
   public enableScreenShare(enable: boolean) {
-    return this._transport.enableScreenShare(enable);
+    try {
+      return this._transport.enableScreenShare(enable);
+    } catch (e) {
+      if (e instanceof RTVIErrors.UnsupportedFeatureError) {
+        this._options.callbacks?.onUnsupportedFeature?.(e);
+        this.emit(RTVIEvent.UnsupportedFeature, e);
+      } else {
+        throw e;
+      }
+    }
   }
 
   public get isSharingScreen(): boolean {

--- a/client-js/rtvi/events.ts
+++ b/client-js/rtvi/events.ts
@@ -5,7 +5,7 @@
  */
 
 import { MediaState, Participant, TransportState } from "./common_types";
-import { DeviceError } from "./errors";
+import { DeviceError, UnsupportedFeatureError } from "./errors";
 import {
   BotLLMSearchResponseData,
   BotLLMTextData,
@@ -105,6 +105,7 @@ export enum RTVIEvent {
   SpeakerUpdated = "speakerUpdated",
   DeviceError = "deviceError",
   MediaStateUpdated = "mediaStateUpdated",
+  UnsupportedFeature = "unsupportedFeature",
 }
 
 export type RTVIEvents = Partial<{
@@ -190,6 +191,7 @@ export type RTVIEvents = Partial<{
   speakerUpdated: (speaker: MediaDeviceInfo) => void;
   deviceError: (error: DeviceError) => void;
   mediaStateUpdated: (mediaState: MediaState) => void;
+  unsupportedFeature: (error: UnsupportedFeatureError) => void;
 }>;
 
 export type RTVIEventHandler<E extends RTVIEvent> = E extends keyof RTVIEvents

--- a/client-js/tests/client.spec.ts
+++ b/client-js/tests/client.spec.ts
@@ -9,7 +9,7 @@ import { beforeEach, describe, expect, test } from "@jest/globals";
 import { FunctionCallCallback, PipecatClient } from "./../client";
 import { messageSizeWithinLimit } from "./../client/utils";
 import { RTVIEvent, RTVIMessage } from "./../rtvi";
-import { MessageTooLargeError } from "./../rtvi/errors";
+import { MessageTooLargeError, UnsupportedFeatureError } from "./../rtvi/errors";
 import { TransportStub } from "./stubs/transport";
 
 describe("PipecatClient Methods", () => {
@@ -579,5 +579,165 @@ describe("Message size validation", () => {
     client.sendClientMessage("test", { data: "small payload" });
 
     expect(errors.length).toBe(0);
+  });
+});
+
+describe("UnsupportedFeatureError handling", () => {
+  // Transport stub that throws UnsupportedFeatureError for cam and screen share
+  class UnsupportedTransportStub extends TransportStub {
+    get selectedCam(): MediaDeviceInfo | Record<string, never> {
+      throw new UnsupportedFeatureError(
+        "selectedCam",
+        "UnsupportedTransportStub",
+        "Not implemented"
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    enableCam(enable: boolean): void {
+      throw new UnsupportedFeatureError(
+        "enableCam",
+        "UnsupportedTransportStub",
+        "Not implemented"
+      );
+    }
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    enableScreenShare(enable: boolean): void {
+      throw new UnsupportedFeatureError(
+        "enableScreenShare",
+        "UnsupportedTransportStub",
+        "Not implemented"
+      );
+    }
+  }
+
+  function createClientWithUnsupportedCallback(
+    onUnsupportedFeature: (error: UnsupportedFeatureError) => void
+  ): PipecatClient {
+    return new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+      callbacks: { onUnsupportedFeature },
+    });
+  }
+
+  test("selectedCam returns {} instead of throwing when transport throws UnsupportedFeatureError", () => {
+    const client = new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+    });
+    expect(() => client.selectedCam).not.toThrow();
+    expect(client.selectedCam).toEqual({});
+  });
+
+  test("selectedCam fires onUnsupportedFeature callback with the error", () => {
+    let received: UnsupportedFeatureError | null = null;
+    const client = createClientWithUnsupportedCallback((e) => (received = e));
+
+    void client.selectedCam;
+
+    expect(received).toBeInstanceOf(UnsupportedFeatureError);
+    expect((received as unknown as UnsupportedFeatureError).feature).toBe("selectedCam");
+  });
+
+  test("selectedCam emits RTVIEvent.UnsupportedFeature", () => {
+    let emitted: UnsupportedFeatureError | null = null;
+    const client = new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+    });
+    client.on(RTVIEvent.UnsupportedFeature, (e) => (emitted = e));
+
+    void client.selectedCam;
+
+    expect(emitted).toBeInstanceOf(UnsupportedFeatureError);
+  });
+
+  test("enableCam does not throw when transport throws UnsupportedFeatureError", () => {
+    const client = new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+    });
+    expect(() => client.enableCam(true)).not.toThrow();
+  });
+
+  test("enableCam fires onUnsupportedFeature callback with the error", () => {
+    let received: UnsupportedFeatureError | null = null;
+    const client = createClientWithUnsupportedCallback((e) => (received = e));
+
+    client.enableCam(true);
+
+    expect(received).toBeInstanceOf(UnsupportedFeatureError);
+    expect((received as unknown as UnsupportedFeatureError).feature).toBe("enableCam");
+  });
+
+  test("enableCam emits RTVIEvent.UnsupportedFeature", () => {
+    let emitted: UnsupportedFeatureError | null = null;
+    const client = new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+    });
+    client.on(RTVIEvent.UnsupportedFeature, (e) => (emitted = e));
+
+    client.enableCam(true);
+
+    expect(emitted).toBeInstanceOf(UnsupportedFeatureError);
+  });
+
+  test("enableScreenShare does not throw when transport throws UnsupportedFeatureError", () => {
+    const client = new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+    });
+    expect(() => client.enableScreenShare(true)).not.toThrow();
+  });
+
+  test("enableScreenShare fires onUnsupportedFeature callback with the error", () => {
+    let received: UnsupportedFeatureError | null = null;
+    const client = createClientWithUnsupportedCallback((e) => (received = e));
+
+    client.enableScreenShare(true);
+
+    expect(received).toBeInstanceOf(UnsupportedFeatureError);
+    expect((received as unknown as UnsupportedFeatureError).feature).toBe("enableScreenShare");
+  });
+
+  test("enableScreenShare emits RTVIEvent.UnsupportedFeature", () => {
+    let emitted: UnsupportedFeatureError | null = null;
+    const client = new PipecatClient({
+      transport: new UnsupportedTransportStub(),
+    });
+    client.on(RTVIEvent.UnsupportedFeature, (e) => (emitted = e));
+
+    client.enableScreenShare(true);
+
+    expect(emitted).toBeInstanceOf(UnsupportedFeatureError);
+  });
+
+  test("selectedCam re-throws non-UnsupportedFeatureError errors", () => {
+    class ErrorTransportStub extends TransportStub {
+      get selectedCam(): MediaDeviceInfo | Record<string, never> {
+        throw new Error("unexpected transport failure");
+      }
+    }
+    const client = new PipecatClient({ transport: new ErrorTransportStub() });
+    expect(() => client.selectedCam).toThrow("unexpected transport failure");
+  });
+
+  test("enableCam re-throws non-UnsupportedFeatureError errors", () => {
+    class ErrorTransportStub extends TransportStub {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      enableCam(enable: boolean): void {
+        throw new Error("unexpected transport failure");
+      }
+    }
+    const client = new PipecatClient({ transport: new ErrorTransportStub() });
+    expect(() => client.enableCam(true)).toThrow("unexpected transport failure");
+  });
+
+  test("enableScreenShare re-throws non-UnsupportedFeatureError errors", () => {
+    class ErrorTransportStub extends TransportStub {
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      enableScreenShare(enable: boolean): void {
+        throw new Error("unexpected transport failure");
+      }
+    }
+    const client = new PipecatClient({ transport: new ErrorTransportStub() });
+    expect(() => client.enableScreenShare(true)).toThrow(
+      "unexpected transport failure"
+    );
   });
 });


### PR DESCRIPTION
  ## Summary
  
  - Added `onUnsupportedFeature` callback and `RTVIEvent.UnsupportedFeature` event to surface transport capability gaps without crashing the application
  - Some transports (e.g. `websocket-transport`) throw `UnsupportedFeatureError` for features like `selectedCam`, `enableCam`, and `enableScreenShare` that they don't implement — previously these propagated as unhandled exceptions
  - `PipecatClient` now catches `UnsupportedFeatureError` in `selectedCam`, `enableCam`, and `enableScreenShare`, routes it through the new event/callback, and returns gracefully instead of throwing 
  
  ## Breaking Changes
  
  None — `onUnsupportedFeature` is an optional entry in the existing `Partial<RTVIEventCallbacks>` type, and `RTVIEvent.UnsupportedFeature` is a new
  enum value. All existing code continues to work unchanged.
  
  ## Testing
  
  Use any transport that doesn't support camera or screen share (e.g. `websocket-transport`) and verify that calling `enableCam()`, `enableScreenShare()`, or reading `selectedCam` no longer throws. Subscribe to the new event to confirm it fires:
  
  ```ts
  client.on(RTVIEvent.UnsupportedFeature, (error) => {
    console.warn("Feature not supported:", error.feature, error.message);
  });
