### PR TITLE
fix(client-react): import client-js types instead of inlining in d.ts

### DIFF
--- a/client-react/tsconfig.json
+++ b/client-react/tsconfig.json
@@ -18,8 +18,7 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@pipecat-ai/client-js": ["../client-js/index.ts"]
+      "@/*": ["./src/*"]
     },
 
     /* Linting */


### PR DESCRIPTION
Fixes #223.

### Problem

`client-react/dist/index.d.ts` inlines a private copy of `@pipecat-ai/client-js`'s types — the `RTVIEvent` enum plus ~70 other declarations — instead of importing them. Because TypeScript enums are nominal, that inlined `RTVIEvent` is a different type from the one consumers import from `@pipecat-ai/client-js`, so `useRTVIClientEvent(RTVIEvent.X, …)` fails to type-check whenever the installed `client-js` diverges from the build-time copy. This is currently broken for anyone on `client-js@1.11.0` (which added `RTVIEvent.UnsupportedFeature` in #221) + `client-react@1.6.0`:

```
error TS2345: Argument of type 'RTVIEvent.BotReady' is not assignable to parameter of type 'RTVIEvent'.
```

### Cause

`client-react/tsconfig.json` aliases `@pipecat-ai/client-js` → `../client-js/index.ts` (local source). Parcel's `@parcel/transformer-typescript-types` follows the alias and inlines client-js's declarations rather than externalizing the peer dependency.

### Fix

Remove the alias. `@pipecat-ai/client-js` then resolves as a normal peer dependency and Parcel emits an `import … from "@pipecat-ai/client-js"` in the `.d.ts`.

```diff
     "paths": {
-      "@/*": ["./src/*"],
-      "@pipecat-ai/client-js": ["../client-js/index.ts"]
+      "@/*": ["./src/*"]
     },
```

### Verification

- `npm run build` (builds `client-js` → `client-react`) succeeds. `dist/index.d.ts` now begins with `import { RTVIEvent, RTVIEventHandler, … } from "@pipecat-ai/client-js"` — no inlined `enum RTVIEvent`. Declaration bundle shrinks **61 kB → 28 kB**; `dist/index.js` is **byte-identical** (runtime unchanged).
- `npm test` (client-react): **235/235 pass**.
- Downstream repro (`client-js@1.11.0` + this build): the `useRTVIClientEvent` / `RTVIEvent` `TS2345` errors are gone, `tsc --noEmit` is clean.

### Notes

- This makes `client-react`'s **type** build depend on `client-js` being built first. The workspace build order (`npm run build` builds `client-js` before `client-react`) and the Build Check CI already guarantee that.
- Jest keeps its own `moduleNameMapper` (`^@pipecat-ai/client-js$` → `../client-js/index.ts`), so tests still resolve to source and are unaffected.
- Only the runtime JS already externalized `client-js` correctly; this aligns the emitted types with that behavior.
