### PR TITLE
feat(react): wire user-llm-text into usePipecatConversation

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -38,6 +38,7 @@ import {
   TranscriptData,
   TransportState,
   UICancelJobGroupData,
+  UserLLMTextData,
   UICommandData,
   UIEventData,
   UIJobGroupData,
@@ -149,6 +150,7 @@ export type RTVIEventCallbacks = Partial<{
   onUserMuteStarted: () => void;
   onUserMuteStopped: () => void;
   onUserTranscript: (data: TranscriptData) => void;
+  onUserLlmText: (data: UserLLMTextData) => void;
   onBotOutput: (data: BotOutputData) => void;
   /** @deprecated Use onBotOutput instead */
   onBotTranscript: (data: BotLLMTextData) => void;
@@ -1142,6 +1144,12 @@ export class PipecatClient extends RTVIEventEmitter {
       case RTVIMessageType.USER_TRANSCRIPTION: {
         const TranscriptData = ev.data as TranscriptData;
         this._options.callbacks?.onUserTranscript?.(TranscriptData);
+        break;
+      }
+      case RTVIMessageType.USER_LLM_TEXT: {
+        const llmTextData = ev.data as UserLLMTextData;
+        this._options.callbacks?.onUserLlmText?.(llmTextData);
+        this.emit(RTVIEvent.UserLlmText, llmTextData);
         break;
       }
       case RTVIMessageType.BOT_OUTPUT: {

--- a/client-js/rtvi/events.ts
+++ b/client-js/rtvi/events.ts
@@ -21,6 +21,7 @@ import {
   TranscriptData,
   UICommandData,
   UIJobGroupData,
+  UserLLMTextData,
 } from "./messages";
 
 export enum RTVIEvent {
@@ -65,6 +66,7 @@ export enum RTVIEvent {
   BotTranscript = "botTranscript",
 
   // llm events
+  UserLlmText = "userLlmText",
   BotLlmText = "botLlmText",
   BotLlmStarted = "botLlmStarted",
   BotLlmStopped = "botLlmStopped",
@@ -150,6 +152,7 @@ export type RTVIEvents = Partial<{
   botTranscript: (data: BotLLMTextData) => void;
 
   // llm events
+  userLlmText: (data: UserLLMTextData) => void;
   botLlmText: (data: BotLLMTextData) => void;
   botLlmStarted: () => void;
   botLlmStopped: () => void;

--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -153,6 +153,10 @@ export type BotLLMTextData = {
   text: string;
 };
 
+export type UserLLMTextData = {
+  text: string;
+};
+
 export type BotTTSTextData = {
   text: string;
 };

--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -130,6 +130,7 @@ export const mergeMessages = (
       lastMerged.role === currentMessage.role &&
       currentMessage.role !== "system" &&
       currentMessage.role !== "function_call" &&
+      !lastMerged.final &&
       timeDiff < MERGE_WINDOW_MS;
 
     if (shouldMerge) {

--- a/client-react/src/conversation/useConversationEventWiring.ts
+++ b/client-react/src/conversation/useConversationEventWiring.ts
@@ -309,6 +309,29 @@ export function useConversationEventWiring() {
     )
   );
 
+  // user-llm-text fires when the user's input reaches the LLM — both in voice
+  // mode (after STT) and in chat mode (typed text, no STT). In voice mode
+  // user-transcription has already created an in-progress user message, so we
+  // only need to finalize it. In chat mode no user message exists yet, so we
+  // create one from the LLM text first, then finalize.
+  useRTVIClientEvent(
+    RTVIEvent.UserLlmText,
+    useAtomCallback(
+      useCallback((get, set, data) => {
+        const messages = get(messagesAtom);
+        const lastUserIdx = findLastIndex(
+          messages,
+          (m: ConversationMessage) => m.role === "user"
+        );
+
+        if (lastUserIdx === -1 || messages[lastUserIdx].final) {
+          upsertUserTranscript(get, set, data.text ?? "", true);
+        }
+        finalizeLastMessage(get, set, "user");
+      }, [])
+    )
+  );
+
   useRTVIClientEvent(
     RTVIEvent.UserStoppedSpeaking,
     useAtomCallback(


### PR DESCRIPTION
Follow-up to #211 — depends on it (branched from that fix, needs `RTVIEvent.UserLlmText` from client-js). Please merge #211 first.

## Problem

In chat mode the server emits `user-llm-text` instead of `user-transcription` (typed text bypasses STT entirely). Because `usePipecatConversation` had no handler for `RTVIEvent.UserLlmText`, user messages were silently dropped and never appeared in the conversation array.

## Solution

Handle `RTVIEvent.UserLlmText` in `useConversationEventWiring` with a guard that avoids duplicating text in voice mode:

- **Voice mode** — `user-transcription` already created an in-progress user message. We skip `upsertUserTranscript` and only call `finalizeLastMessage` to mark the turn complete.
- **Chat mode** — No in-progress user message exists. We create one from the LLM text, then finalize it.

```ts
useRTVIClientEvent(
  RTVIEvent.UserLlmText,
  useAtomCallback(
    useCallback((get, set, data) => {
      const messages = get(messagesAtom);
      const lastUserIdx = findLastIndex(
        messages,
        (m: ConversationMessage) => m.role === "user"
      );

      if (lastUserIdx === -1 || messages[lastUserIdx].final) {
        upsertUserTranscript(get, set, data.text ?? "", true);
      }
      finalizeLastMessage(get, set, "user");
    }, [])
  )
);
```

## Changes

| File | Change |
|---|---|
| `client-react/src/conversation/useConversationEventWiring.ts` | Wire `RTVIEvent.UserLlmText` with voice/chat mode guard |

## Test plan

- [ ] **Chat mode**: user messages appear in the conversation array via `usePipecatConversation`
- [ ] **Voice mode**: no duplicate user text — `user-transcription` message is finalized, not duplicated
- [ ] Existing `UserTranscript` behavior unchanged
- [ ] TypeScript builds cleanly once #211 is merged (`tsc --noEmit`)