### PR TITLE
Adding support to RTVI protocol 2.0.0

### DIFF
--- a/client-react/src/conversation/botOutput.ts
+++ b/client-react/src/conversation/botOutput.ts
@@ -28,6 +28,7 @@ export type BotOutputMessageCursor = {
   hasReceivedUnspoken: boolean;
 };
 
+/** @deprecated Protocol 1.4.x only. Not used in the 2.0.0 path. */
 export const normalizeForMatching = (text: string): string => {
   return text.toLowerCase().replace(/[^\p{L}\p{N}\s]/gu, "");
 };
@@ -169,6 +170,8 @@ export function hasUnspokenContent(
  * advance — pure punctuation is consumed without moving the cursor), or false
  * if there was nothing to consume (e.g. no parts, all parts already spoken).
  * Used to detect "spoken-only" bots that never send unspoken events.
+ *
+ * @deprecated Protocol 1.4.x only. Use `applySpokenProgressV2` for RTVI 2.0.0+.
  */
 export function applySpokenBotOutputProgress(
   cursor: BotOutputMessageCursor,
@@ -289,4 +292,63 @@ export function applySpokenBotOutputProgress(
   }
 
   return false;
+}
+
+/**
+ * Applies a `spoken_progress` update directly to the cursor using the
+ * server-provided split from RTVI Protocol 2.0.0+.
+ *
+ * The server sends `accumulated_text` (already spoken) and `remaining_text`
+ * (not yet spoken) for the active segment. When `segmentId` is provided the
+ * target part is located by matching `part.segment_id`; this ensures progress
+ * events are always applied to the correct part even when multiple segments
+ * are in flight. Falls back to `currentPartIndex` when no match is found.
+ */
+export function applySpokenProgressV2(
+  cursor: BotOutputMessageCursor,
+  parts: ConversationMessagePart[],
+  accumulatedText: string,
+  segmentId?: number
+): void {
+  if (parts.length === 0) return;
+
+  // Locate the target part by segment_id when available.
+  let targetPartIndex = -1;
+  if (segmentId !== undefined) {
+    for (let i = 0; i < parts.length; i++) {
+      if (parts[i].segment_id === segmentId) {
+        targetPartIndex = i;
+        break;
+      }
+    }
+  }
+
+  // Fall back to the cursor's current position if no segment_id match.
+  if (targetPartIndex === -1) {
+    targetPartIndex = Math.min(cursor.currentPartIndex, parts.length - 1);
+    // Advance past already-finalized parts.
+    while (
+      targetPartIndex < parts.length - 1 &&
+      cursor.partFinalFlags[targetPartIndex]
+    ) {
+      targetPartIndex++;
+    }
+  }
+
+  const targetPart = parts[targetPartIndex];
+  if (typeof targetPart?.text !== "string") return;
+
+  const partText = targetPart.text;
+  const newCharIndex = Math.min(accumulatedText.length, partText.length);
+
+  cursor.currentPartIndex = targetPartIndex;
+  cursor.currentCharIndex = newCharIndex;
+
+  if (newCharIndex >= partText.length) {
+    cursor.partFinalFlags[targetPartIndex] = true;
+    if (targetPartIndex < parts.length - 1) {
+      cursor.currentPartIndex = targetPartIndex + 1;
+      cursor.currentCharIndex = 0;
+    }
+  }
 }

--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -591,7 +591,7 @@ export function updateAssistantBotOutput(
 
   if (payload.protocol === "v2") {
     // -------------------------------------------------------------------------
-    // RTVI Protocol 2.0.0 path
+    // RTVI Protocol 2.x.x path
     // -------------------------------------------------------------------------
     const { will_be_spoken, spoken_status, spoken_progress, segment_id } =
       payload;

--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -9,6 +9,7 @@ import type { ReactNode } from "react";
 
 import {
   applySpokenBotOutputProgress,
+  applySpokenProgressV2,
   hasUnspokenContent,
   normalizeForMatching,
 } from "./botOutput";
@@ -467,18 +468,42 @@ export function upsertUserTranscript(
   set(messagesAtom, processedMessages);
 }
 
+type BotOutputPayloadLegacy = {
+  protocol: "legacy";
+  /** @deprecated Protocol 1.4.x only. */
+  spoken: boolean;
+};
+
+type BotOutputPayloadV2 = {
+  protocol: "v2";
+  will_be_spoken: boolean;
+  spoken_status?: "new" | "in-progress" | "completed";
+  spoken_progress?: { accumulated_text: string; remaining_text: string };
+  segment_id?: number;
+};
+
+export type BotOutputPayload = BotOutputPayloadLegacy | BotOutputPayloadV2;
+
 export function updateAssistantBotOutput(
   get: Getter,
   set: Setter,
   text: string,
   final: boolean,
-  spoken: boolean,
+  payload: BotOutputPayload,
   aggregatedBy?: string
 ) {
-  // Strip turn-completion markers emitted by FilterIncompleteTurns before
-  // the text enters conversation state.
-  text = stripTurnCompletionMarker(text);
-  if (text.length === 0) return;
+  // v2 progress events carry no text — they only advance the cursor.
+  // Skip text stripping and the empty-text guard for those.
+  const isV2ProgressEvent =
+    payload.protocol === "v2" &&
+    (payload.spoken_status === "in-progress" || payload.spoken_status === "completed");
+
+  if (!isV2ProgressEvent) {
+    // Strip turn-completion markers emitted by FilterIncompleteTurns before
+    // the text enters conversation state.
+    text = stripTurnCompletionMarker(text);
+    if (text.length === 0) return;
+  }
 
   const now = new Date();
   const messages = [...get(messagesAtom)];
@@ -537,12 +562,24 @@ export function updateAssistantBotOutput(
   // Store raw event for debugging/replay
   const botOutputEvents = new Map(get(botOutputEventsAtom));
   const existingEvents = botOutputEvents.get(messageId) || [];
-  const rawEvent: BotOutputEvent = {
-    text,
-    spoken,
-    aggregatedBy: aggregatedBy,
-    receivedAt: now.toISOString(),
-  };
+  const rawEvent: BotOutputEvent =
+    payload.protocol === "v2"
+      ? {
+          text,
+          spoken: false, // legacy field unused in v2
+          aggregatedBy,
+          receivedAt: now.toISOString(),
+          will_be_spoken: payload.will_be_spoken,
+          spoken_status: payload.spoken_status,
+          spoken_progress: payload.spoken_progress,
+          segment_id: payload.segment_id,
+        }
+      : {
+          text,
+          spoken: payload.spoken,
+          aggregatedBy,
+          receivedAt: now.toISOString(),
+        };
   botOutputEvents.set(messageId, [...existingEvents, rawEvent]);
 
   const messageState = botOutputMessageState.get(messageId)!;
@@ -552,211 +589,268 @@ export function updateAssistantBotOutput(
     ];
   const parts = [...(message.parts || [])];
 
-  if (!spoken) {
-    // UNSPOKEN EVENT: Create/update message parts immediately
-    // Only append when both current and last part are word-level; sentence-level
-    // and other types each get their own part so spoken events can match 1:1.
-    const isDefaultType =
-      aggregatedBy === "sentence" ||
-      aggregatedBy === "word" ||
-      !aggregatedBy;
-    const lastPart = parts[parts.length - 1];
-    const shouldAppend =
-      lastPart &&
-      aggregatedBy === "word" &&
-      lastPart.aggregatedBy === "word" &&
-      typeof lastPart.text === "string" &&
-      !messageState.partSpokenOnly[parts.length - 1];
+  if (payload.protocol === "v2") {
+    // -------------------------------------------------------------------------
+    // RTVI Protocol 2.0.0 path
+    // -------------------------------------------------------------------------
+    const { will_be_spoken, spoken_status, spoken_progress, segment_id } =
+      payload;
 
-    if (shouldAppend) {
-      // Append to last part (word-level only)
-      const lastPartText = lastPart.text as string;
-      const separator =
-        lastPartText && !lastPartText.endsWith(" ") && !text.startsWith(" ")
-          ? " "
-          : "";
-      parts[parts.length - 1] = {
-        ...lastPart,
-        text: lastPartText + separator + text,
+    if (!will_be_spoken || spoken_status === "new") {
+      // Each v2 event is a self-contained segment — always a new part.
+      // Word-level aggregation does not exist in Protocol 2.0.0.
+      const isDefaultType = aggregatedBy === "sentence" || !aggregatedBy;
+      const newPart: ConversationMessagePart = {
+        text,
+        final: false,
+        createdAt: now.toISOString(),
+        aggregatedBy,
+        displayMode: isDefaultType ? "inline" : undefined,
+        segment_id,
+        // Signal to the renderer that a separator space should precede this part.
+        // The stored text is always the original segment text from the server.
+        needsSeparator: parts.length > 0,
       };
-    } else {
-      // Before creating a new unspoken part, check whether the trailing run
-      // of spoken-only fallback parts forms a word-prefix of this new text.
-      // If so, absorb them: S2S pipelines can emit word-level spoken events
-      // for a sentence before the sentence-level unspoken event arrives.
-      let scanStart = parts.length;
-      while (
-        scanStart > 0 &&
-        messageState.partSpokenOnly[scanStart - 1] &&
-        typeof parts[scanStart - 1].text === "string"
-      ) {
-        scanStart--;
+      parts.push(newPart);
+      messageState.partFinalFlags.push(false);
+      messageState.partSpokenOnly.push(false);
+
+      if (will_be_spoken) {
+        messageState.hasReceivedUnspoken = true;
       }
 
-      // Character-level prefix match: concatenate the alphanumeric chars
-      // of each trailing spoken-only part in order and check that the
-      // running concatenation is a prefix of the new text's alphanumeric
-      // chars. This handles TTS sub-word splits (e.g. "Pi"/"pec"/"at"
-      // speaking "Pipecat") that a word-level matcher can't reconcile.
-      let absorbed = 0;
-      let absorbedAlnumCount = 0;
-      if (scanStart < parts.length) {
-        const alnumOnly = (s: string): string =>
-          s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
-        const textAlnum = alnumOnly(text);
-        let running = 0;
-        for (let i = scanStart; i < parts.length; i++) {
-          const partAlnum = alnumOnly(parts[i].text as string);
-          if (partAlnum.length === 0) {
-            // Pure-punctuation fragment: absorb silently without extending
-            // the running prefix (same semantics as applySpokenBotOutputProgress).
-            absorbed++;
-            continue;
-          }
-          const next = running + partAlnum.length;
-          if (
-            next <= textAlnum.length &&
-            textAlnum.slice(running, next) === partAlnum
-          ) {
-            running = next;
-            absorbedAlnumCount = running;
-            absorbed++;
-          } else {
-            break;
-          }
+      messages[
+        lastAssistantIndex === -1 ? messages.length - 1 : lastAssistantIndex
+      ] = { ...message, parts };
+    } else if (spoken_status === "in-progress" && spoken_progress) {
+      // TTS is actively speaking: the server gives us the exact split.
+      applySpokenProgressV2(
+        messageState,
+        parts,
+        spoken_progress.accumulated_text,
+        segment_id
+      );
+    } else if (spoken_status === "completed") {
+      // TTS finished this segment: advance cursor to end of current part.
+      applySpokenProgressV2(
+        messageState,
+        parts,
+        spoken_progress?.accumulated_text ?? (parts[messageState.currentPartIndex]?.text as string ?? ""),
+        segment_id
+      );
+    }
+  } else {
+    // -------------------------------------------------------------------------
+    // RTVI Protocol 1.4.x (legacy) path
+    // -------------------------------------------------------------------------
+    const spoken = payload.spoken;
+
+    if (!spoken) {
+      // UNSPOKEN EVENT: Create/update message parts immediately
+      // Only append when both current and last part are word-level; sentence-level
+      // and other types each get their own part so spoken events can match 1:1.
+      const isDefaultType =
+        aggregatedBy === "sentence" ||
+        aggregatedBy === "word" ||
+        !aggregatedBy;
+      const lastPart = parts[parts.length - 1];
+      const shouldAppend =
+        lastPart &&
+        aggregatedBy === "word" &&
+        lastPart.aggregatedBy === "word" &&
+        typeof lastPart.text === "string" &&
+        !messageState.partSpokenOnly[parts.length - 1];
+
+      if (shouldAppend) {
+        // Append to last part (word-level only)
+        const lastPartText = lastPart.text as string;
+        const separator =
+          lastPartText && !lastPartText.endsWith(" ") && !text.startsWith(" ")
+            ? " "
+            : "";
+        parts[parts.length - 1] = {
+          ...lastPart,
+          text: lastPartText + separator + text,
+        };
+      } else {
+        // Before creating a new unspoken part, check whether the trailing run
+        // of spoken-only fallback parts forms a word-prefix of this new text.
+        // If so, absorb them: S2S pipelines can emit word-level spoken events
+        // for a sentence before the sentence-level unspoken event arrives.
+        let scanStart = parts.length;
+        while (
+          scanStart > 0 &&
+          messageState.partSpokenOnly[scanStart - 1] &&
+          typeof parts[scanStart - 1].text === "string"
+        ) {
+          scanStart--;
         }
-      }
 
-      // Translate the absorbed alphanumeric prefix count into a char
-      // index inside the original (non-normalized) unspoken text,
-      // advancing past any trailing punctuation and whitespace so the
-      // cursor sits at the start of the next unspoken word.
-      let absorbedCharIndex = 0;
-      if (absorbedAlnumCount > 0) {
-        const isAlnum = (c: string): boolean => /[\p{L}\p{N}]/u.test(c);
-        let count = 0;
-        for (let i = 0; i < text.length; i++) {
-          if (isAlnum(text[i])) {
-            count++;
-            if (count === absorbedAlnumCount) {
-              let j = i + 1;
-              while (j < text.length && !isAlnum(text[j])) j++;
-              absorbedCharIndex = j;
+        // Character-level prefix match: concatenate the alphanumeric chars
+        // of each trailing spoken-only part in order and check that the
+        // running concatenation is a prefix of the new text's alphanumeric
+        // chars. This handles TTS sub-word splits (e.g. "Pi"/"pec"/"at"
+        // speaking "Pipecat") that a word-level matcher can't reconcile.
+        let absorbed = 0;
+        let absorbedAlnumCount = 0;
+        if (scanStart < parts.length) {
+          const alnumOnly = (s: string): string =>
+            s.toLowerCase().replace(/[^\p{L}\p{N}]/gu, "");
+          const textAlnum = alnumOnly(text);
+          let running = 0;
+          for (let i = scanStart; i < parts.length; i++) {
+            const partAlnum = alnumOnly(parts[i].text as string);
+            if (partAlnum.length === 0) {
+              // Pure-punctuation fragment: absorb silently without extending
+              // the running prefix (same semantics as applySpokenBotOutputProgress).
+              absorbed++;
+              continue;
+            }
+            const next = running + partAlnum.length;
+            if (
+              next <= textAlnum.length &&
+              textAlnum.slice(running, next) === partAlnum
+            ) {
+              running = next;
+              absorbedAlnumCount = running;
+              absorbed++;
+            } else {
               break;
             }
           }
         }
-      }
 
-      // Create new part (sentence-level, custom types, or first word chunk)
-      // Default to inline; custom types get displayMode from metadata in the hook
-      const defaultDisplayMode = isDefaultType ? "inline" : undefined;
-      const newPart: ConversationMessagePart = {
-        text: text, // Store full text as string
-        final: false, // Will be evaluated in hook based on metadata
-        createdAt: now.toISOString(),
-        aggregatedBy,
-        displayMode: defaultDisplayMode,
-      };
-
-      if (absorbed > 0) {
-        // Replace the absorbed spoken-only parts in place so the new
-        // unspoken part sits where its spoken fragments originally landed
-        // (before any trailing fallback parts that belong to later turns).
-        const insertAt = scanStart;
-        parts.splice(insertAt, absorbed, newPart);
-        messageState.partFinalFlags.splice(insertAt, absorbed, false);
-        messageState.partSpokenOnly.splice(insertAt, absorbed, false);
-
-        if (absorbedCharIndex > 0) {
-          messageState.currentPartIndex = insertAt;
-          messageState.currentCharIndex = absorbedCharIndex;
-          if (absorbedCharIndex >= text.length) {
-            messageState.partFinalFlags[insertAt] = true;
+        // Translate the absorbed alphanumeric prefix count into a char
+        // index inside the original (non-normalized) unspoken text,
+        // advancing past any trailing punctuation and whitespace so the
+        // cursor sits at the start of the next unspoken word.
+        let absorbedCharIndex = 0;
+        if (absorbedAlnumCount > 0) {
+          const isAlnum = (c: string): boolean => /[\p{L}\p{N}]/u.test(c);
+          let count = 0;
+          for (let i = 0; i < text.length; i++) {
+            if (isAlnum(text[i])) {
+              count++;
+              if (count === absorbedAlnumCount) {
+                let j = i + 1;
+                while (j < text.length && !isAlnum(text[j])) j++;
+                absorbedCharIndex = j;
+                break;
+              }
+            }
           }
         }
-      } else {
-        parts.push(newPart);
-        messageState.partFinalFlags.push(false);
-        messageState.partSpokenOnly.push(false);
-      }
-    }
 
-    messageState.hasReceivedUnspoken = true;
+        // Create new part (sentence-level, custom types, or first word chunk)
+        // Default to inline; custom types get displayMode from metadata in the hook
+        const defaultDisplayMode = isDefaultType ? "inline" : undefined;
+        const newPart: ConversationMessagePart = {
+          text: text, // Store full text as string
+          final: false, // Will be evaluated in hook based on metadata
+          createdAt: now.toISOString(),
+          aggregatedBy,
+          displayMode: defaultDisplayMode,
+        };
 
-    // Update message with new parts
-    messages[
-      lastAssistantIndex === -1 ? messages.length - 1 : lastAssistantIndex
-    ] = {
-      ...message,
-      parts,
-    };
-  } else {
-    // SPOKEN EVENT: advance cursor into existing text, or add as new part
-    // if there is none. Multi-word events (e.g. TTS emitting "Hello! I'm"
-    // as a single chunk that crosses a sentence boundary) are split into
-    // whitespace-separated tokens and processed one at a time so the
-    // cursor can advance across unspoken-part boundaries.
-    const tokens = text.trim().split(/\s+/).filter(Boolean);
-    const leadingSpace = /^\s/.test(text) ? " " : "";
-    const isDefaultType =
-      aggregatedBy === "sentence" ||
-      aggregatedBy === "word" ||
-      !aggregatedBy;
-    const defaultDisplayMode = isDefaultType ? "inline" : undefined;
+        if (absorbed > 0) {
+          // Replace the absorbed spoken-only parts in place so the new
+          // unspoken part sits where its spoken fragments originally landed
+          // (before any trailing fallback parts that belong to later turns).
+          const insertAt = scanStart;
+          parts.splice(insertAt, absorbed, newPart);
+          messageState.partFinalFlags.splice(insertAt, absorbed, false);
+          messageState.partSpokenOnly.splice(insertAt, absorbed, false);
 
-    let partsMutated = false;
-    for (let tokenIdx = 0; tokenIdx < tokens.length; tokenIdx++) {
-      const tokenText =
-        (tokenIdx === 0 ? leadingSpace : " ") + tokens[tokenIdx];
-      const advanced =
-        parts.length > 0 &&
-        applySpokenBotOutputProgress(messageState, parts, tokenText);
-
-      if (advanced) continue;
-
-      if (messageState.hasReceivedUnspoken) {
-        if (hasUnspokenContent(messageState, parts)) {
-          // Mid-stream: the unspoken stream is authoritative for this
-          // message and still has pending content to be spoken. An
-          // unmatched spoken token here is TTS-granularity noise (e.g.
-          // "Pi" / "pec" / "at" tokenization of "Pipecat"). Drop.
-          continue;
-        }
-        if (normalizeForMatching(tokenText).trim().length === 0) {
-          // Trailing punctuation after every part has been consumed has
-          // nothing to attach to. Drop silently.
-          continue;
+          if (absorbedCharIndex > 0) {
+            messageState.currentPartIndex = insertAt;
+            messageState.currentCharIndex = absorbedCharIndex;
+            if (absorbedCharIndex >= text.length) {
+              messageState.partFinalFlags[insertAt] = true;
+            }
+          }
+        } else {
+          parts.push(newPart);
+          messageState.partFinalFlags.push(false);
+          messageState.partSpokenOnly.push(false);
         }
       }
 
-      // Either no unspoken content has ever been seen (spoken-only bot),
-      // or every part has been fully consumed and this token likely
-      // belongs to the next sentence — whose unspoken event hasn't arrived
-      // yet. Add as a spoken-only fallback so a later unspoken event can
-      // absorb it.
-      const newPart: ConversationMessagePart = {
-        text: tokenText,
-        final: false,
-        createdAt: now.toISOString(),
-        aggregatedBy,
-        displayMode: defaultDisplayMode,
-      };
-      parts.push(newPart);
-      messageState.partFinalFlags.push(true);
-      messageState.partSpokenOnly.push(true);
-      messageState.currentPartIndex = parts.length - 1;
-      messageState.currentCharIndex = tokenText.length;
-      partsMutated = true;
-    }
+      messageState.hasReceivedUnspoken = true;
 
-    if (partsMutated) {
+      // Update message with new parts
       messages[
         lastAssistantIndex === -1 ? messages.length - 1 : lastAssistantIndex
       ] = {
         ...message,
         parts,
       };
+    } else {
+      // SPOKEN EVENT: advance cursor into existing text, or add as new part
+      // if there is none. Multi-word events (e.g. TTS emitting "Hello! I'm"
+      // as a single chunk that crosses a sentence boundary) are split into
+      // whitespace-separated tokens and processed one at a time so the
+      // cursor can advance across unspoken-part boundaries.
+      const tokens = text.trim().split(/\s+/).filter(Boolean);
+      const leadingSpace = /^\s/.test(text) ? " " : "";
+      const isDefaultType =
+        aggregatedBy === "sentence" ||
+        aggregatedBy === "word" ||
+        !aggregatedBy;
+      const defaultDisplayMode = isDefaultType ? "inline" : undefined;
+
+      let partsMutated = false;
+      for (let tokenIdx = 0; tokenIdx < tokens.length; tokenIdx++) {
+        const tokenText =
+          (tokenIdx === 0 ? leadingSpace : " ") + tokens[tokenIdx];
+        const advanced =
+          parts.length > 0 &&
+          applySpokenBotOutputProgress(messageState, parts, tokenText);
+
+        if (advanced) continue;
+
+        if (messageState.hasReceivedUnspoken) {
+          if (hasUnspokenContent(messageState, parts)) {
+            // Mid-stream: the unspoken stream is authoritative for this
+            // message and still has pending content to be spoken. An
+            // unmatched spoken token here is TTS-granularity noise (e.g.
+            // "Pi" / "pec" / "at" tokenization of "Pipecat"). Drop.
+            continue;
+          }
+          if (normalizeForMatching(tokenText).trim().length === 0) {
+            // Trailing punctuation after every part has been consumed has
+            // nothing to attach to. Drop silently.
+            continue;
+          }
+        }
+
+        // Either no unspoken content has ever been seen (spoken-only bot),
+        // or every part has been fully consumed and this token likely
+        // belongs to the next sentence — whose unspoken event hasn't arrived
+        // yet. Add as a spoken-only fallback so a later unspoken event can
+        // absorb it.
+        const newPart: ConversationMessagePart = {
+          text: tokenText,
+          final: false,
+          createdAt: now.toISOString(),
+          aggregatedBy,
+          displayMode: defaultDisplayMode,
+        };
+        parts.push(newPart);
+        messageState.partFinalFlags.push(true);
+        messageState.partSpokenOnly.push(true);
+        messageState.currentPartIndex = parts.length - 1;
+        messageState.currentCharIndex = tokenText.length;
+        partsMutated = true;
+      }
+
+      if (partsMutated) {
+        messages[
+          lastAssistantIndex === -1 ? messages.length - 1 : lastAssistantIndex
+        ] = {
+          ...message,
+          parts,
+        };
+      }
     }
   }
 

--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -492,18 +492,10 @@ export function updateAssistantBotOutput(
   payload: BotOutputPayload,
   aggregatedBy?: string
 ) {
-  // v2 progress events carry no text — they only advance the cursor.
-  // Skip text stripping and the empty-text guard for those.
-  const isV2ProgressEvent =
-    payload.protocol === "v2" &&
-    (payload.spoken_status === "in-progress" || payload.spoken_status === "completed");
-
-  if (!isV2ProgressEvent) {
-    // Strip turn-completion markers emitted by FilterIncompleteTurns before
-    // the text enters conversation state.
-    text = stripTurnCompletionMarker(text);
-    if (text.length === 0) return;
-  }
+  // Strip turn-completion markers emitted by FilterIncompleteTurns before
+  // the text enters conversation state.
+  text = stripTurnCompletionMarker(text);
+  if (text.length === 0) return;
 
   const now = new Date();
   const messages = [...get(messagesAtom)];

--- a/client-react/src/conversation/conversationAtoms.ts
+++ b/client-react/src/conversation/conversationAtoms.ts
@@ -31,6 +31,9 @@ export const messageCallbacksAtom = atom<Map<string, MessageCallbacks>>(
 /** Whether BotOutput events are supported (RTVI 1.1.0+): null = unknown, true/false = detected */
 export const botOutputSupportedAtom = atom<boolean | null>(null);
 
+/** Which BotOutput protocol version is active. null = unknown (pre-BotReady). */
+export const botOutputProtocolAtom = atom<"legacy" | "v2" | null>(null);
+
 /** Raw BotOutput events per message (keyed by message createdAt), for debugging/replay */
 export const botOutputEventsAtom = atom<Map<string, BotOutputEvent[]>>(
   new Map()

--- a/client-react/src/conversation/types.ts
+++ b/client-react/src/conversation/types.ts
@@ -42,12 +42,17 @@ export interface BotOutputFilter {
 export interface BotOutputEvent {
   /** The raw text from the BotOutput event */
   text: string;
-  /** Whether this was a spoken (TTS) event */
+  /** @deprecated Protocol 1.4.x only. Use `will_be_spoken` instead. */
   spoken: boolean;
   /** Aggregation type (e.g., "sentence", "word", "code") */
   aggregatedBy?: string;
   /** ISO timestamp of when the event was received */
   receivedAt: string;
+  // Protocol 2.0.0+ fields
+  will_be_spoken?: boolean;
+  spoken_status?: "new" | "in-progress" | "completed";
+  spoken_progress?: { accumulated_text: string; remaining_text: string };
+  segment_id?: number;
 }
 
 /**
@@ -102,6 +107,18 @@ export interface ConversationMessagePart {
    * Used to determine which custom renderer to use, if any
    */
   aggregatedBy?: string;
+  /**
+   * RTVI Protocol 2.0.0+ segment identifier. Used to correlate progress
+   * events (`spoken_status: "in-progress" | "completed"`) back to the
+   * part they belong to.
+   */
+  segment_id?: number;
+  /**
+   * RTVI Protocol 2.0.0+ only. When true, the renderer should prepend an
+   * inter-segment separator (a space) before this part's text. The stored
+   * `text` is always the original segment text as received from the server.
+   */
+  needsSeparator?: boolean;
   /**
    * Display mode for BotOutput content.
    * - "inline": Rendered inline with surrounding text (default for sentence-level)

--- a/client-react/src/conversation/useConversationEventWiring.ts
+++ b/client-react/src/conversation/useConversationEventWiring.ts
@@ -19,6 +19,7 @@ import { useRTVIClientEvent } from "../useRTVIClientEvent";
 import { hasUnspokenContent } from "./botOutput";
 import {
   addMessage,
+  type BotOutputPayload,
   clearMessages,
   finalizeLastMessage,
   handleFunctionCallInProgress,
@@ -31,6 +32,7 @@ import {
 } from "./conversationActions";
 import {
   botOutputMessageStateAtom,
+  botOutputProtocolAtom,
   botOutputSupportedAtom,
   messagesAtom,
 } from "./conversationAtoms";
@@ -145,6 +147,7 @@ export function useConversationEventWiring() {
       useCallback((get, set) => {
         clearMessages(get, set);
         set(botOutputSupportedAtom, null);
+        set(botOutputProtocolAtom, null);
         clearTimeout(botStoppedSpeakingTimeoutRef.current);
         botStoppedSpeakingTimeoutRef.current = undefined;
         botOutputLastChunkRef.current = { spoken: "", unspoken: "" };
@@ -158,7 +161,16 @@ export function useConversationEventWiring() {
       useCallback((_get, set, botData: BotReadyData) => {
         const rtviVersion = botData.version;
         const supportsBotOutput = isMinVersion(rtviVersion, [1, 1, 0]);
+        const isV2 = isMinVersion(rtviVersion, [2, 0, 0]);
         set(botOutputSupportedAtom, supportsBotOutput);
+        set(botOutputProtocolAtom, isV2 ? "v2" : "legacy");
+        if (isV2) {
+          console.debug(`[Pipecat Client] Bot protocol version ${rtviVersion} — using RTVI 2.0.0 path (server-side speech progress).`);
+        } else if (supportsBotOutput) {
+          console.debug(`[Pipecat Client] Bot protocol version ${rtviVersion} — using legacy RTVI path (client-side speech progress).`);
+        } else {
+          console.debug(`[Pipecat Client] Bot protocol version ${rtviVersion} — BotOutput events not supported (requires RTVI 1.1.0+).`);
+        }
       }, [])
     )
   );
@@ -173,36 +185,74 @@ export function useConversationEventWiring() {
           clearTimeout(botStoppedSpeakingTimeoutRef.current);
           botStoppedSpeakingTimeoutRef.current = undefined;
 
-          ensureAssistantMessage();
+          const protocol = get(botOutputProtocolAtom) ?? "legacy";
 
-          // Handle spacing for BotOutput chunks
-          let textToAdd = data.text;
-          const lastChunk = data.spoken
-            ? botOutputLastChunkRef.current.spoken
-            : botOutputLastChunkRef.current.unspoken;
+          if (protocol === "v2") {
+            // Protocol 2.0.0: progress events (in-progress/completed) carry no
+            // new text to display — they only advance the cursor. Skip
+            // ensureAssistantMessage and spacing for those.
+            const spoken_status = data.spoken_status;
+            const isProgressEvent =
+              spoken_status === "in-progress" || spoken_status === "completed";
 
-          // Add space separator if needed between BotOutput chunks
-          if (lastChunk) {
-            textToAdd = " " + textToAdd;
-          }
+            if (!isProgressEvent) {
+              ensureAssistantMessage();
+            }
 
-          // Update the appropriate last chunk tracker
-          if (data.spoken) {
-            botOutputLastChunkRef.current.spoken = textToAdd;
+            const payload: BotOutputPayload = {
+              protocol: "v2",
+              will_be_spoken: data.will_be_spoken ?? false,
+              spoken_status: data.spoken_status,
+              spoken_progress: data.spoken_progress,
+              segment_id: data.segment_id,
+            };
+
+            const isFinal = data.aggregated_by === "sentence";
+            updateAssistantBotOutput(
+              get,
+              set,
+              data.text,
+              isFinal,
+              payload,
+              data.aggregated_by
+            );
           } else {
-            botOutputLastChunkRef.current.unspoken = textToAdd;
-          }
+            // Protocol 1.4.x (legacy): use spoken boolean with inter-chunk spacing.
+            ensureAssistantMessage();
 
-          // Update both spoken and unspoken text streams
-          const isFinal = data.aggregated_by === "sentence";
-          updateAssistantBotOutput(
-            get,
-            set,
-            textToAdd,
-            isFinal,
-            data.spoken,
-            data.aggregated_by
-          );
+            const isSpoken = data.will_be_spoken ?? data.spoken ?? false;
+
+            // Handle spacing for BotOutput chunks
+            let textToAdd = data.text;
+            const lastChunk = isSpoken
+              ? botOutputLastChunkRef.current.spoken
+              : botOutputLastChunkRef.current.unspoken;
+
+            if (lastChunk) {
+              textToAdd = " " + textToAdd;
+            }
+
+            if (isSpoken) {
+              botOutputLastChunkRef.current.spoken = textToAdd;
+            } else {
+              botOutputLastChunkRef.current.unspoken = textToAdd;
+            }
+
+            const payload: BotOutputPayload = {
+              protocol: "legacy",
+              spoken: isSpoken,
+            };
+
+            const isFinal = data.aggregated_by === "sentence";
+            updateAssistantBotOutput(
+              get,
+              set,
+              textToAdd,
+              isFinal,
+              payload,
+              data.aggregated_by
+            );
+          }
         },
         [ensureAssistantMessage]
       )

--- a/client-react/src/usePipecatConversation.ts
+++ b/client-react/src/usePipecatConversation.ts
@@ -200,11 +200,16 @@ export const usePipecatConversation = ({
                 ? ""
                 : partText;
 
+            // For v2 segments that follow another segment, prepend the separator
+            // space to the spoken bucket so it appears immediately. The stored
+            // text is the original segment text and is never modified.
+            const separator = part.needsSeparator ? " " : "";
+
             return {
               ...part,
               displayMode,
               text: filterBotOutputText(
-                { spoken: spokenText, unspoken: unspokenText },
+                { spoken: separator + spokenText, unspoken: unspokenText },
                 botOutputFilter
               ),
             };

--- a/client-react/tests/conversation/helpers/storeHarness.ts
+++ b/client-react/tests/conversation/helpers/storeHarness.ts
@@ -4,6 +4,7 @@ import {
   type BotOutputMessageCursor,
   hasUnspokenContent,
 } from "@/conversation/botOutput";
+import type { BotOutputPayload } from "@/conversation/conversationActions";
 import * as actions from "@/conversation/conversationActions";
 import {
   botOutputMessageStateAtom,
@@ -103,8 +104,45 @@ export function createStoreHarness() {
       store.set,
       textToAdd,
       isFinal,
-      spoken,
+      { protocol: "legacy", spoken },
       aggregatedBy
+    );
+  }
+
+  /**
+   * Emit a BotOutput event using RTVI Protocol 2.0.0 semantics, replicating
+   * the spacing and routing logic from useConversationEventWiring.
+   *
+   * For content events (spoken_status "new" or undefined, or will_be_spoken false):
+   *   - ensures an assistant message exists
+   *   - prepends an inter-segment space when a previous content event was seen
+   *
+   * For progress events (spoken_status "in-progress" | "completed"):
+   *   - only advances the cursor; no new text is added
+   */
+  function emitBotOutputV2(params: {
+    text: string;
+    will_be_spoken?: boolean;
+    spoken_status?: "new" | "in-progress" | "completed";
+    spoken_progress?: { accumulated_text: string; remaining_text: string };
+    segment_id?: number;
+    aggregated_by?: string;
+  }) {
+    const { text, will_be_spoken = false, spoken_status, spoken_progress, segment_id, aggregated_by } = params;
+    const isProgressEvent = spoken_status === "in-progress" || spoken_status === "completed";
+
+    if (!isProgressEvent) {
+      ensureAssistantMessage();
+    }
+
+    const isFinal = aggregated_by === "sentence";
+    actions.updateAssistantBotOutput(
+      store.get,
+      store.set,
+      text,
+      isFinal,
+      { protocol: "v2", will_be_spoken, spoken_status, spoken_progress, segment_id },
+      aggregated_by
     );
   }
 
@@ -263,7 +301,7 @@ export function createStoreHarness() {
   function updateAssistantBotOutput(
     text: string,
     final: boolean,
-    spoken: boolean,
+    payload: BotOutputPayload,
     aggregatedBy?: string
   ) {
     actions.updateAssistantBotOutput(
@@ -271,7 +309,7 @@ export function createStoreHarness() {
       store.set,
       text,
       final,
-      spoken,
+      payload,
       aggregatedBy
     );
   }
@@ -301,6 +339,7 @@ export function createStoreHarness() {
     reset,
     ensureAssistantMessage,
     emitBotOutput,
+    emitBotOutputV2,
     emitUserTranscript,
     finalizeAssistant,
     finalizeUser,

--- a/client-react/tests/conversation/stores/botOutputV2.test.ts
+++ b/client-react/tests/conversation/stores/botOutputV2.test.ts
@@ -1,0 +1,198 @@
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { createStoreHarness } from "../helpers/storeHarness";
+
+describe("RTVI Protocol 2.0.0 – BotOutput v2", () => {
+  let harness: ReturnType<typeof createStoreHarness>;
+
+  beforeEach(() => {
+    harness = createStoreHarness();
+    harness.reset();
+  });
+
+  // -------------------------------------------------------------------------
+  // Text accumulation
+  // -------------------------------------------------------------------------
+  describe("text accumulation", () => {
+    it("creates a part for a will_be_spoken=false event", () => {
+      harness.emitBotOutputV2({ text: "Hello world", will_be_spoken: false, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0].text).toBe("Hello world");
+    });
+
+    it("creates a part for a new spoken segment", () => {
+      harness.emitBotOutputV2({ text: "Hello world", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(1);
+      expect(parts[0].text).toBe("Hello world");
+      expect(parts[0].segment_id).toBe(1);
+    });
+
+    it("stores original text unchanged for consecutive segments", () => {
+      harness.emitBotOutputV2({ text: "Hello world.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "How are you?", will_be_spoken: true, spoken_status: "new", segment_id: 2, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].text).toBe("Hello world.");
+      expect(parts[1].text).toBe("How are you?");
+    });
+
+    it("sets needsSeparator=true on the second segment, false on the first", () => {
+      harness.emitBotOutputV2({ text: "Hello.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "Goodbye.", will_be_spoken: true, spoken_status: "new", segment_id: 2, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts[0].needsSeparator).toBeFalsy();
+      expect(parts[1].needsSeparator).toBe(true);
+    });
+
+    it("does not add space before the very first segment", () => {
+      harness.emitBotOutputV2({ text: "First.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts[0].text).toBe("First.");
+      expect(parts[0].needsSeparator).toBeFalsy();
+    });
+
+    it("each segment always creates its own part (no word-level aggregation in v2)", () => {
+      harness.emitBotOutputV2({ text: "First segment.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "Second segment.", will_be_spoken: true, spoken_status: "new", segment_id: 2, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "Third segment.", will_be_spoken: true, spoken_status: "new", segment_id: 3, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(3);
+      expect(parts[0].text).toBe("First segment.");
+      expect(parts[1].text).toBe("Second segment.");
+      expect(parts[2].text).toBe("Third segment.");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Cursor advancement via spoken_progress
+  // -------------------------------------------------------------------------
+  describe("cursor advancement", () => {
+    it("advances cursor on in-progress event using accumulated_text length", () => {
+      harness.emitBotOutputV2({ text: "Hello world.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({
+        text: "",
+        will_be_spoken: true,
+        spoken_status: "in-progress",
+        spoken_progress: { accumulated_text: "Hello", remaining_text: " world." },
+        segment_id: 1,
+      });
+
+      const cursor = harness.getLastAssistantCursor();
+      expect(cursor).toBeDefined();
+      expect(cursor!.currentCharIndex).toBe(5); // "Hello".length
+    });
+
+    it("cursor maps directly to original text with no offset for second segment", () => {
+      harness.emitBotOutputV2({ text: "Hello.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "World.", will_be_spoken: true, spoken_status: "new", segment_id: 2, aggregated_by: "sentence" });
+
+      // Progress on second segment: accumulated_text="Wor" (3 chars into "World.")
+      // Part text is "World." (unchanged); cursor should be at exactly 3
+      harness.emitBotOutputV2({
+        text: "",
+        will_be_spoken: true,
+        spoken_status: "in-progress",
+        spoken_progress: { accumulated_text: "Wor", remaining_text: "ld." },
+        segment_id: 2,
+      });
+
+      const cursor = harness.getLastAssistantCursor();
+      expect(cursor).toBeDefined();
+      expect(cursor!.currentCharIndex).toBe(3); // directly "Wor".length, no offset
+    });
+
+    it("marks part as final on completed event with full accumulated_text", () => {
+      harness.emitBotOutputV2({ text: "Hello.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({
+        text: "",
+        will_be_spoken: true,
+        spoken_status: "completed",
+        spoken_progress: { accumulated_text: "Hello.", remaining_text: "" },
+        segment_id: 1,
+      });
+
+      const cursor = harness.getLastAssistantCursor();
+      expect(cursor).toBeDefined();
+      expect(cursor!.partFinalFlags[0]).toBe(true);
+    });
+
+    it("targets the correct part by segment_id when multiple segments exist", () => {
+      harness.emitBotOutputV2({ text: "Segment one.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "Segment two.", will_be_spoken: true, spoken_status: "new", segment_id: 2, aggregated_by: "sentence" });
+
+      // Progress for segment 1 (already created, cursor starts at 0)
+      harness.emitBotOutputV2({
+        text: "",
+        will_be_spoken: true,
+        spoken_status: "in-progress",
+        spoken_progress: { accumulated_text: "Segment", remaining_text: " one." },
+        segment_id: 1,
+      });
+
+      const cursor = harness.getLastAssistantCursor();
+      expect(cursor).toBeDefined();
+      // Cursor should be on part 0 (segment 1), not part 1 (segment 2)
+      expect(cursor!.currentPartIndex).toBe(0);
+      expect(cursor!.currentCharIndex).toBe(7); // "Segment".length
+    });
+
+    it("progress event does not create a new part", () => {
+      harness.emitBotOutputV2({ text: "Hello.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      const partsBefore = harness.getMessages()[0].parts.length;
+
+      harness.emitBotOutputV2({
+        text: "",
+        will_be_spoken: true,
+        spoken_status: "in-progress",
+        spoken_progress: { accumulated_text: "Hel", remaining_text: "lo." },
+        segment_id: 1,
+      });
+
+      expect(harness.getMessages()[0].parts.length).toBe(partsBefore);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // Mixed will_be_spoken
+  // -------------------------------------------------------------------------
+  describe("mixed will_be_spoken", () => {
+    it("creates separate parts for spoken and non-spoken segments", () => {
+      harness.emitBotOutputV2({ text: "Spoken text.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "Silent text.", will_be_spoken: false, aggregated_by: "sentence" });
+
+      const parts = harness.getMessages()[0].parts;
+      expect(parts).toHaveLength(2);
+      expect(parts[0].text).toBe("Spoken text.");
+      expect(parts[1].text).toBe("Silent text.");
+      expect(parts[1].needsSeparator).toBe(true);
+    });
+
+    it("does not set hasReceivedUnspoken for will_be_spoken=false events", () => {
+      harness.emitBotOutputV2({ text: "Silent text.", will_be_spoken: false, aggregated_by: "sentence" });
+
+      const cursor = harness.getLastAssistantCursor();
+      expect(cursor).toBeDefined();
+      expect(cursor!.hasReceivedUnspoken).toBe(false);
+    });
+
+    it("sets hasReceivedUnspoken=true for will_be_spoken=true events", () => {
+      harness.emitBotOutputV2({ text: "Hello.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+
+      const cursor = harness.getLastAssistantCursor();
+      expect(cursor).toBeDefined();
+      expect(cursor!.hasReceivedUnspoken).toBe(true);
+    });
+  });
+});

--- a/client-react/tests/conversation/stores/conversationStore.test.ts
+++ b/client-react/tests/conversation/stores/conversationStore.test.ts
@@ -1,4 +1,3 @@
-import { createStoreHarness } from "../helpers/storeHarness";
 import {
   filterEmptyMessages,
   isMessageEmpty,
@@ -6,6 +5,8 @@ import {
   stripTurnCompletionMarker,
 } from "@/conversation/conversationActions";
 import type { ConversationMessage } from "@/conversation/types";
+
+import { createStoreHarness } from "../helpers/storeHarness";
 
 /** Helper: create a minimal message for merge/filter tests. */
 function msg(
@@ -177,8 +178,8 @@ describe("conversationStore", () => {
         parts: [],
       });
 
-      harness.updateAssistantBotOutput("Hello", false, false, "word");
-      harness.updateAssistantBotOutput(" world", false, false, "word");
+      harness.updateAssistantBotOutput("Hello", false, { protocol: "legacy", spoken: false }, "word");
+      harness.updateAssistantBotOutput(" world", false, { protocol: "legacy", spoken: false }, "word");
 
       const parts = harness.getMessages()[0].parts;
       expect(parts).toHaveLength(1);
@@ -196,13 +197,13 @@ describe("conversationStore", () => {
       harness.updateAssistantBotOutput(
         "First sentence.",
         true,
-        false,
+        { protocol: "legacy", spoken: false },
         "sentence"
       );
       harness.updateAssistantBotOutput(
         "Second sentence.",
         true,
-        false,
+        { protocol: "legacy", spoken: false },
         "sentence"
       );
 
@@ -222,13 +223,13 @@ describe("conversationStore", () => {
       harness.updateAssistantBotOutput(
         "Some text",
         false,
-        false,
+        { protocol: "legacy", spoken: false },
         "sentence"
       );
       harness.updateAssistantBotOutput(
         "console.log('hi')",
         false,
-        false,
+        { protocol: "legacy", spoken: false },
         "code"
       );
 
@@ -250,11 +251,11 @@ describe("conversationStore", () => {
       });
 
       // First send unspoken
-      harness.updateAssistantBotOutput("Hello", false, false, "word");
-      harness.updateAssistantBotOutput(" world", false, false, "word");
+      harness.updateAssistantBotOutput("Hello", false, { protocol: "legacy", spoken: false }, "word");
+      harness.updateAssistantBotOutput(" world", false, { protocol: "legacy", spoken: false }, "word");
 
       // Then spoken
-      harness.updateAssistantBotOutput("Hello", false, true, "word");
+      harness.updateAssistantBotOutput("Hello", false, { protocol: "legacy", spoken: true }, "word");
 
       const cursor = harness.getBotOutputState().values().next().value;
       expect(cursor).toBeDefined();
@@ -269,7 +270,7 @@ describe("conversationStore", () => {
       });
 
       // Spoken without prior unspoken
-      harness.updateAssistantBotOutput("Hello", false, true, "word");
+      harness.updateAssistantBotOutput("Hello", false, { protocol: "legacy", spoken: true }, "word");
 
       const parts = harness.getMessages()[0].parts;
       expect(parts).toHaveLength(1);
@@ -453,7 +454,7 @@ describe("conversationStore", () => {
         parts: [],
       });
 
-      harness.updateAssistantBotOutput("✓ Japan", false, false, "word");
+      harness.updateAssistantBotOutput("✓ Japan", false, { protocol: "legacy", spoken: false }, "word");
 
       const parts = harness.getMessages()[0].parts;
       expect(parts).toHaveLength(1);
@@ -467,7 +468,7 @@ describe("conversationStore", () => {
         parts: [],
       });
 
-      harness.updateAssistantBotOutput("○", false, false, "word");
+      harness.updateAssistantBotOutput("○", false, { protocol: "legacy", spoken: false }, "word");
 
       const parts = harness.getMessages()[0].parts;
       expect(parts).toHaveLength(0);
@@ -480,7 +481,7 @@ describe("conversationStore", () => {
         parts: [],
       });
 
-      harness.updateAssistantBotOutput("✓ Hello", false, true, "word");
+      harness.updateAssistantBotOutput("✓ Hello", false, { protocol: "legacy", spoken: true }, "word");
 
       const parts = harness.getMessages()[0].parts;
       expect(parts).toHaveLength(1);


### PR DESCRIPTION
## client-react changes
  
  - Detects the bot's protocol version on `BotReady` and routes `BotOutput` events through either a **legacy path** (Protocol 1.4.x,   client-side word-matching cursor) or a new **v2 path** (Protocol 2.0.0, server-provided `spoken_progress`)
  - Adds `applySpokenProgressV2` to `botOutput.ts`: sets the cursor directly from `accumulated_text.length` using `segment_id` to target the correct part — no word-matching needed
  - Adds a `needsSeparator` flag to `ConversationMessagePart` so the renderer can inject an inter-segment space at display time without modifying the stored segment text 
  - Adds `botOutputProtocolAtom` to track the active protocol version across the session
  - All existing legacy behaviour is preserved and remains the default for bots that haven't upgraded
  
  ## Breaking Changes
  
  - `updateAssistantBotOutput` in `conversationActions.ts` now takes a `BotOutputPayload` discriminated union (`{ protocol: "legacy", spoken }` | `{ protocol: "v2", ... }`) instead of a plain `spoken: boolean` argument — affects any code calling this internal function directly