### PR TITLE
chore(js): force release 1.12.0 for RTVI protocol 2.0.0 (#215)

### DIFF
--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -12,6 +12,7 @@ import {
 } from "../package.json";
 import type { A11ySnapshot, UIJobGroupEnvelope } from "./ui";
 
+// Protocol 2.0.0 adds server-driven bot-output progress (spoken_progress, segment_id).
 export const RTVI_PROTOCOL_VERSION = "2.0.0";
 export const RTVI_MESSAGE_LABEL = "rtvi-ai";
 


### PR DESCRIPTION
## Why

The `feat(js)` and `fix(js)` commits from #215 (RTVI protocol 2.0.0 bot-output-progress support) were merged via a merge commit and missed by release-please's commit traversal, so client-js release PR #227 only captured an unrelated fix (1.11.1) instead of the feature.

This anchors the release-please attribution to the client-js component (touches a client-js file) and uses a `Release-As` footer to force the version that should have shipped.

The squash-merge commit message includes `Release-As: 1.12.0` so release-please bumps client-js to 1.12.0 on the next run.