### PR TITLE
Add DTMF support to client-js and client-react, with key-sequence sending

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -18,6 +18,8 @@ import {
   ClientMessageData,
   DeviceErrorReason,
   DeviceStatus,
+  DTMFButton,
+  DTMFData,
   ErrorData,
   LLMContextMessage,
   LLMFunctionCallData,
@@ -39,11 +41,11 @@ import {
   TranscriptData,
   TransportState,
   UICancelJobGroupData,
-  UserLLMTextData,
   UICommandData,
   UIEventData,
   UIJobGroupData,
   UISnapshotData,
+  UserLLMTextData,
 } from "../rtvi";
 import * as RTVIErrors from "../rtvi/errors";
 import {
@@ -996,6 +998,18 @@ export class PipecatClient extends RTVIEventEmitter {
   public sendUIEvent(event: string, payload?: unknown): void {
     const data: UIEventData = { event, payload };
     this._sendMessage(new RTVIMessage(RTVIMessageType.UI_EVENT, data));
+  }
+
+  /**
+   * Send a single DTMF tone to the server as a first-class RTVI
+   * `dtmf` message. Call once per key.
+   *
+   * @param button - The DTMF key to send (0-9, *, or #).
+   */
+  @transportReady
+  public sendDTMF(button: DTMFButton): void {
+    const data: DTMFData = { button };
+    this._sendMessage(new RTVIMessage(RTVIMessageType.DTMF, data));
   }
 
   /**

--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -231,6 +231,9 @@ export class PipecatClient extends RTVIEventEmitter {
   private _botTranscriptionWarned = false;
   private _llmFunctionCallWarned = false;
 
+  // Bot's RTVI protocol version, parsed from bot-ready. [0, 0, 0] until known.
+  private _botVersion: number[] = [0, 0, 0];
+
   // Per-device device state. Independent of TransportState — driven by
   // initDevices() and DeviceError events, never by transport connect/disconnect.
   // See common_types.ts for the rationale and the daily-react reference.
@@ -678,6 +681,7 @@ export class PipecatClient extends RTVIEventEmitter {
    */
   public async disconnect(): Promise<void> {
     this.stopUISnapshotStream();
+    this._botVersion = [0, 0, 0];
     await this._transport.disconnect();
     this._messageDispatcher.disconnect();
   }
@@ -1001,15 +1005,38 @@ export class PipecatClient extends RTVIEventEmitter {
   }
 
   /**
-   * Send a single DTMF tone to the server as a first-class RTVI
-   * `dtmf` message. Call once per key.
+   * Send DTMF tones to the server as first-class RTVI `dtmf` messages.
    *
-   * @param button - The DTMF key to send (0-9, *, or #).
+   * Accepts a single key or a sequence of keys (e.g. "123#"). Bots on
+   * RTVI protocol 2.1.0+ receive the keys as a single message; 2.0.x
+   * bots receive one legacy `{button}` message per key. Bots older than
+   * 2.0.0 don't support DTMF at all.
+   *
+   * @param dtmf - The DTMF key(s) to send (0-9, *, or #).
    */
   @transportReady
-  public sendDTMF(button: DTMFButton): void {
-    const data: DTMFData = { button };
-    this._sendMessage(new RTVIMessage(RTVIMessageType.DTMF, data));
+  public sendDTMF(dtmf: DTMFButton | string): void {
+    if (!/^[0-9*#]+$/.test(dtmf)) {
+      throw new RTVIErrors.RTVIError(
+        `Invalid DTMF sequence "${dtmf}". Only 0-9, * and # are allowed.`
+      );
+    }
+    if (this._botVersion[0] < 2) {
+      throw new RTVIErrors.UnsupportedFeatureError(
+        "DTMF",
+        "bot",
+        "requires RTVI protocol 2.0.0+"
+      );
+    }
+    const buttons = [...dtmf] as DTMFButton[];
+    if (this._botVersion[0] === 2 && this._botVersion[1] < 1) {
+      for (const button of buttons) {
+        this._sendMessage(new RTVIMessage(RTVIMessageType.DTMF, { button }));
+      }
+    } else {
+      const data: DTMFData = { buttons };
+      this._sendMessage(new RTVIMessage(RTVIMessageType.DTMF, data));
+    }
   }
 
   /**
@@ -1145,6 +1172,7 @@ export class PipecatClient extends RTVIEventEmitter {
         const botVersion = data.version
           ? data.version.split(".").map(Number)
           : [0, 0, 0];
+        this._botVersion = botVersion;
         logger.debug(`[Pipecat Client] Bot is ready. Version: ${data.version}`);
         if (botVersion[0] < 2) {
           logger.warn(

--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -13,7 +13,7 @@ import {
 import type { A11ySnapshot, UIJobGroupEnvelope } from "./ui";
 
 // Protocol 2.0.0 adds server-driven bot-output progress (spoken_progress, segment_id).
-export const RTVI_PROTOCOL_VERSION = "2.0.0";
+export const RTVI_PROTOCOL_VERSION = "2.1.0";
 export const RTVI_MESSAGE_LABEL = "rtvi-ai";
 
 /**
@@ -278,7 +278,9 @@ export type DTMFButton =
   | "#";
 
 export type DTMFData = {
-  button: DTMFButton;
+  /** One or more DTMF keys, in order. Requires a bot on RTVI protocol
+   * 2.1.0+; older bots expect a legacy `{button}` message per key. */
+  buttons: DTMFButton[];
 };
 
 /** DEPRECATED */

--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -27,6 +27,7 @@ export enum RTVIMessageType {
   // Client-to-server messages
   CLIENT_MESSAGE = "client-message",
   SEND_TEXT = "send-text",
+  DTMF = "dtmf",
   // UI Worker Protocol (client-to-server)
   UI_EVENT = "ui-event",
   UI_SNAPSHOT = "ui-snapshot",
@@ -259,6 +260,25 @@ export type LLMFunctionCallStoppedData = {
 export type SendTextOptions = {
   run_immediately?: boolean;
   audio_response?: boolean;
+};
+
+/** Valid DTMF keypad keys. */
+export type DTMFButton =
+  | "0"
+  | "1"
+  | "2"
+  | "3"
+  | "4"
+  | "5"
+  | "6"
+  | "7"
+  | "8"
+  | "9"
+  | "*"
+  | "#";
+
+export type DTMFData = {
+  button: DTMFButton;
 };
 
 /** DEPRECATED */

--- a/client-js/tests/client-ui-worker.spec.ts
+++ b/client-js/tests/client-ui-worker.spec.ts
@@ -264,6 +264,28 @@ describe("PipecatClient UI inbound events", () => {
   });
 });
 
+describe("PipecatClient.sendDTMF", () => {
+  it("sends a first-class dtmf RTVI message with the button", () => {
+    const client = makeMockPipecatClient();
+
+    client.sendDTMF("1");
+
+    expect(sendMock(client)).toHaveBeenCalledTimes(1);
+    expectSentMessage(client, RTVIMessageType.DTMF, { button: "1" });
+  });
+
+  it("sends one message per call", () => {
+    const client = makeMockPipecatClient();
+
+    client.sendDTMF("*");
+    client.sendDTMF("#");
+
+    expect(sendMock(client)).toHaveBeenCalledTimes(2);
+    expectSentMessage(client, RTVIMessageType.DTMF, { button: "*" });
+    expectSentMessage(client, RTVIMessageType.DTMF, { button: "#" });
+  });
+});
+
 describe("PipecatClient.cancelUIJobGroup", () => {
   it("sends a first-class ui-cancel-job-group RTVI message with job_id", () => {
     const client = makeMockPipecatClient();

--- a/client-js/tests/client-ui-worker.spec.ts
+++ b/client-js/tests/client-ui-worker.spec.ts
@@ -46,7 +46,7 @@ function makeMockPipecatClient(): MockPipecatClient {
 
   const mock = Object.create(PipecatClient.prototype) as MockPipecatClient;
   (mock as unknown as MessageMockHolder)._sendMessage = jest.fn();
-  Object.assign(mock, { _transport: { state: "ready" } });
+  Object.assign(mock, { _transport: { state: "ready" }, _botVersion: [0, 0, 0] });
   mock.on = jest.fn((event: unknown, handler: unknown) => {
     get(event as RTVIEvent).add(handler as Listener);
     return mock;
@@ -265,24 +265,60 @@ describe("PipecatClient UI inbound events", () => {
 });
 
 describe("PipecatClient.sendDTMF", () => {
-  it("sends a first-class dtmf RTVI message with the button", () => {
+  it("sends a sequence as a single buttons message when the bot is on protocol 2.1.0+", () => {
     const client = makeMockPipecatClient();
+    Object.assign(client, { _botVersion: [2, 1, 0] });
+
+    client.sendDTMF("123#");
+
+    expect(sendMock(client)).toHaveBeenCalledTimes(1);
+    expectSentMessage(client, RTVIMessageType.DTMF, {
+      buttons: ["1", "2", "3", "#"],
+    });
+  });
+
+  it("sends a single key as a one-element buttons message on protocol 2.1.0+", () => {
+    const client = makeMockPipecatClient();
+    Object.assign(client, { _botVersion: [2, 1, 0] });
 
     client.sendDTMF("1");
 
     expect(sendMock(client)).toHaveBeenCalledTimes(1);
-    expectSentMessage(client, RTVIMessageType.DTMF, { button: "1" });
+    expectSentMessage(client, RTVIMessageType.DTMF, { buttons: ["1"] });
   });
 
-  it("sends one message per call", () => {
+  it("fans out legacy button messages, one per key, for pre-2.1.0 bots", () => {
+    const client = makeMockPipecatClient();
+    Object.assign(client, { _botVersion: [2, 0, 0] });
+
+    client.sendDTMF("12#");
+
+    expect(sendMock(client)).toHaveBeenCalledTimes(3);
+    expect(
+      sendMock(client).mock.calls.map(
+        (c) => (c[0] as RTVIMessage).data
+      )
+    ).toEqual([{ button: "1" }, { button: "2" }, { button: "#" }]);
+  });
+
+  it("throws when the bot predates DTMF support (protocol < 2.0.0 or unknown)", () => {
     const client = makeMockPipecatClient();
 
-    client.sendDTMF("*");
-    client.sendDTMF("#");
+    expect(() => client.sendDTMF("42")).toThrow(/does not support DTMF/);
 
-    expect(sendMock(client)).toHaveBeenCalledTimes(2);
-    expectSentMessage(client, RTVIMessageType.DTMF, { button: "*" });
-    expectSentMessage(client, RTVIMessageType.DTMF, { button: "#" });
+    Object.assign(client, { _botVersion: [1, 4, 0] });
+    expect(() => client.sendDTMF("1")).toThrow(/does not support DTMF/);
+
+    expect(sendMock(client)).not.toHaveBeenCalled();
+  });
+
+  it("throws on invalid input and sends nothing", () => {
+    const client = makeMockPipecatClient();
+    Object.assign(client, { _botVersion: [2, 1, 0] });
+
+    expect(() => client.sendDTMF("12a#")).toThrow();
+    expect(() => client.sendDTMF("")).toThrow();
+    expect(sendMock(client)).not.toHaveBeenCalled();
   });
 });
 

--- a/client-react/src/index.ts
+++ b/client-react/src/index.ts
@@ -33,6 +33,7 @@ import { PipecatClientScreenShareToggle } from "./PipecatClientScreenShareToggle
 import { PipecatClientVideo } from "./PipecatClientVideo";
 import { UIJobGroupsContext } from "./UIJobGroupsContext";
 import { UIJobGroupsProvider } from "./UIJobGroupsProvider";
+import { useDTMF } from "./useDTMF";
 import { usePipecatClient } from "./usePipecatClient";
 import { usePipecatClientCamControl } from "./usePipecatClientCamControl";
 import { usePipecatClientMediaDevices } from "./usePipecatClientMediaDevices";
@@ -72,6 +73,7 @@ export {
   useDefaultSelectTextHandler,
   useDefaultSetInputValueHandler,
   useDefaultUICommandHandlers,
+  useDTMF,
   useMediaState,
   useNavigateHandler,
   usePipecatClient,

--- a/client-react/src/useDTMF.ts
+++ b/client-react/src/useDTMF.ts
@@ -1,0 +1,28 @@
+/**
+ * Copyright (c) 2026, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import type { DTMFButton } from "@pipecat-ai/client-js";
+import { useCallback } from "react";
+
+import { usePipecatClient } from "./usePipecatClient";
+
+/**
+ * Returns a `sendTone` callable that sends a single DTMF tone to the server.
+ *
+ * The returned function is a no-op until the Pipecat client is available
+ * from the ambient `PipecatClientProvider`.
+ */
+export const useDTMF = () => {
+  const client = usePipecatClient();
+  const sendTone = useCallback(
+    (button: DTMFButton) => {
+      if (!client) return;
+      client.sendDTMF(button);
+    },
+    [client],
+  );
+  return { sendTone };
+};

--- a/client-react/src/useDTMF.ts
+++ b/client-react/src/useDTMF.ts
@@ -10,7 +10,8 @@ import { useCallback } from "react";
 import { usePipecatClient } from "./usePipecatClient";
 
 /**
- * Returns a `sendTone` callable that sends a single DTMF tone to the server.
+ * Returns a `sendTone` callable that sends DTMF tones to the server.
+ * Accepts a single key or a sequence of keys (e.g. "123#").
  *
  * The returned function is a no-op until the Pipecat client is available
  * from the ambient `PipecatClientProvider`.
@@ -18,9 +19,9 @@ import { usePipecatClient } from "./usePipecatClient";
 export const useDTMF = () => {
   const client = usePipecatClient();
   const sendTone = useCallback(
-    (button: DTMFButton) => {
+    (dtmf: DTMFButton | string) => {
       if (!client) return;
-      client.sendDTMF(button);
+      client.sendDTMF(dtmf);
     },
     [client],
   );

--- a/client-react/tests/ui/useDTMF.spec.tsx
+++ b/client-react/tests/ui/useDTMF.spec.tsx
@@ -48,6 +48,31 @@ describe("useDTMF", () => {
     expect(sendDTMF).toHaveBeenCalledWith("1");
   });
 
+  it("passes a multi-key sequence through to sendDTMF", () => {
+    const sendDTMF = jest.fn();
+    mockUsePipecatClient.mockReturnValue({
+      sendDTMF,
+    });
+
+    let sendTone: (dtmf: DTMFButton | string) => void = () => {
+      throw new Error("sendTone not yet bound");
+    };
+
+    const Probe: React.FC = () => {
+      ({ sendTone } = useDTMF());
+      return null;
+    };
+
+    render(<Probe />);
+
+    act(() => {
+      sendTone("123#");
+    });
+
+    expect(sendDTMF).toHaveBeenCalledTimes(1);
+    expect(sendDTMF).toHaveBeenCalledWith("123#");
+  });
+
   it("is a no-op when the Pipecat client is unavailable", () => {
     mockUsePipecatClient.mockReturnValue(undefined);
 

--- a/client-react/tests/ui/useDTMF.spec.tsx
+++ b/client-react/tests/ui/useDTMF.spec.tsx
@@ -1,0 +1,71 @@
+/**
+ * Copyright (c) 2026, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { beforeEach, describe, expect, it, jest } from "@jest/globals";
+import type { DTMFButton } from "@pipecat-ai/client-js";
+import { act, render } from "@testing-library/react";
+import React from "react";
+
+import { useDTMF } from "../../src/useDTMF";
+import { usePipecatClient } from "../../src/usePipecatClient";
+
+jest.mock("../../src/usePipecatClient", () => ({
+  usePipecatClient: jest.fn(),
+}));
+
+const mockUsePipecatClient = usePipecatClient as unknown as jest.Mock;
+
+describe("useDTMF", () => {
+  beforeEach(() => {
+    mockUsePipecatClient.mockReset();
+  });
+
+  it("sends a tone through the ambient Pipecat client", () => {
+    const sendDTMF = jest.fn();
+    mockUsePipecatClient.mockReturnValue({
+      sendDTMF,
+    });
+
+    let sendTone: (button: DTMFButton) => void = () => {
+      throw new Error("sendTone not yet bound");
+    };
+
+    const Probe: React.FC = () => {
+      ({ sendTone } = useDTMF());
+      return null;
+    };
+
+    render(<Probe />);
+
+    act(() => {
+      sendTone("1");
+    });
+
+    expect(sendDTMF).toHaveBeenCalledTimes(1);
+    expect(sendDTMF).toHaveBeenCalledWith("1");
+  });
+
+  it("is a no-op when the Pipecat client is unavailable", () => {
+    mockUsePipecatClient.mockReturnValue(undefined);
+
+    let sendTone: (button: DTMFButton) => void = () => {
+      throw new Error("sendTone not yet bound");
+    };
+
+    const Probe: React.FC = () => {
+      ({ sendTone } = useDTMF());
+      return null;
+    };
+
+    render(<Probe />);
+
+    expect(() => {
+      act(() => {
+        sendTone("#");
+      });
+    }).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- **client-js**: new `DTMFButton` type (`0`–`9`, `*`, `#`) and a `sendDTMF(dtmf)` method on `PipecatClient` that accepts a single key or a whole key sequence (e.g. `"123#"`). Invalid characters throw an `RTVIError`.
- **client-react**: new `useDTMF()` hook returning `{ sendTone }`, following the existing sender-hook patterns; `sendTone` accepts the same single key or sequence.
- **Wire format / compatibility**: the client tracks the bot's RTVI protocol version from `bot-ready`. Bots on protocol 2.1.0+ (pipecat-ai/pipecat#5030) receive one `{ type: "dtmf", data: { buttons: ["1", "2", "3", "#"] } }` message; 2.0.x bots (pipecat 1.5.x) receive one legacy `{ button }` message per key, so DTMF works against every deployed server that supports it. Bots older than protocol 2.0.0 (or with no advertised version) predate the `dtmf` message entirely, so `sendDTMF` throws `UnsupportedFeatureError` instead of silently sending messages they'd reject. `RTVI_PROTOCOL_VERSION` is bumped to `2.1.0`.

## Test plan
- [x] Jest suites pass for both packages, covering: a sequence as a single `buttons` message to 2.1.0+ bots, a single key as a one-element `buttons` message, per-key legacy fan-out for 2.0.x bots, `UnsupportedFeatureError` for pre-2.0.0/unknown bot versions, and invalid input throwing without sending
- [x] `tsc --noEmit` and `eslint` pass for both packages
- [ ] Manual: against a pipecat bot with a `DTMFAggregator`, call `client.sendDTMF("123#")` and confirm the keys aggregate into one transcription
- [ ] Manual: `useDTMF().sendTone("#")` from a React component dispatches the same message
