### PR TITLE
chore: drop (main) scope from Release Please PR title

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -3,6 +3,7 @@
   "release-type": "node",
   "include-component-in-tag": true,
   "separate-pull-requests": true,
+  "pull-request-title-pattern": "chore: release${component} ${version}",
   "packages": {
     "client-js": {
       "component": "client-js",


### PR DESCRIPTION
## Problem

Release Please PRs fail the **Lint Commits** check. The release commit subject reads:

```
chore(main): release <component> <version>
```

`.commitlintrc.json` restricts `scope-enum` to `js`, `react`, and empty, so `(main)` is rejected. Because a Release Please PR contains only the release commit, and `lint-commits.yml` requires *at least one* conventional commit, the whole check fails.

## Cause

The `(main)` comes from Release Please's default `pull-request-title-pattern`:

```
chore${scope}: release${component} ${version}
```

where `${scope}` resolves to `(main)` (the target branch). That same subject is carried by the release PR's commit that commitlint inspects.

## Fix

Override the pattern to drop `${scope}`:

```json
"pull-request-title-pattern": "chore: release${component} ${version}"
```

This yields `chore: release <component> <version>` (empty scope, which is allowed).

## Verification

Validated against the repo's exact `.commitlintrc.json`:

- `chore: release client-js 1.12.0` → passes
- `chore: release client-react 1.7.1` → passes
- old `chore(main): release client-js 1.12.0` → `scope must be one of [js, react, ]` (confirms diagnosis)

## Note

Takes effect on the next Release Please PR it generates (next push to `main`). An already-open release PR keeps its current commit until Release Please regenerates it.