### PR TITLE
fix(client-react): stop bundling client-js types into the published d.ts

### DIFF
--- a/client-react/tsconfig.json
+++ b/client-react/tsconfig.json
@@ -18,8 +18,7 @@
     /* Path aliases */
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@pipecat-ai/client-js": ["../client-js/index.ts"]
+      "@/*": ["./src/*"]
     },
 
     /* Linting */


### PR DESCRIPTION
The `@pipecat-ai/client-js` -> `../client-js/index.ts` path alias made Parcel's TypeScript type bundler resolve client-js to local source and inline it into `dist/index.d.ts`. As a result the published types declared their own duplicate `PipecatClient` class (referencing a bare `"client-js"` module) instead of re-exporting the one from `@pipecat-ai/client-js`.

That duplicate is nominally distinct from the real client-js `PipecatClient` (protected members), so a client-js `PipecatClient` instance is not assignable to `PipecatClientProvider`'s `client` prop. Any TypeScript consumer that creates a `PipecatClient` and passes it to the provider fails to type-check (and downstream `.d.ts` builds break).

Removing the alias lets the type bundler treat `@pipecat-ai/client-js` as an external dependency again, so the emitted `dist/index.d.ts` imports `PipecatClient`, `DTMFButton`, etc. from `@pipecat-ai/client-js` with no inlined duplicate. The runtime bundle already externalized client-js correctly; only the type build was affected.

Note: client-react now type-checks against client-js's built declarations, so build client-js before client-react (the workspace build order already does this).