### PR TITLE
- Version gate checks protocol < 2.2 (was < 1.3, which let 2.0/2.1 bo…

### DIFF
--- a/client-js/client/client.ts
+++ b/client-js/client/client.ts
@@ -1168,8 +1168,8 @@ export class PipecatClient extends RTVIEventEmitter {
     options: SendFileOptions = {}
   ) {
     if (
-      this._botVersion[0] < 1 ||
-      (this._botVersion[0] === 1 && this._botVersion[1] < 3)
+      this._botVersion[0] < 2 ||
+      (this._botVersion[0] === 2 && this._botVersion[1] < 2)
     ) {
       throw new RTVIErrors.UnsupportedFeatureError(
         "sendFile",
@@ -1177,7 +1177,7 @@ export class PipecatClient extends RTVIEventEmitter {
         "requires RTVI protocol 2.2.0+"
       );
     }
-    let rtvi_file = file instanceof File ? ({} as RTVIFile) : file;
+    let rtvi_file = file instanceof File ? ({} as RTVIFile) : { ...file };
     let mimeType: string =
       file instanceof File ? file.type : rtvi_file.format.toLowerCase();
     if (mimeType in MimeTypeMapping) {
@@ -1205,23 +1205,33 @@ export class PipecatClient extends RTVIEventEmitter {
       if (estimatedEncodedSize > this._transport.maxMessageSize) {
         uploadFile = file;
       } else {
-        return new Promise<void>((resolve) => {
+        return new Promise<void>((resolve, reject) => {
           const reader = new FileReader();
+          reader.onerror = () => {
+            reject(new RTVIErrors.RTVIError("Could not read file data"));
+          };
           reader.onload = async (e) => {
-            if (!e.target?.result) {
-              throw new RTVIErrors.RTVIError("Could not read file data");
-            }
-            const fileContent = e.target.result as string;
+            try {
+              if (!e.target?.result) {
+                throw new RTVIErrors.RTVIError("Could not read file data");
+              }
+              const dataUrl = e.target.result as string;
+              // FileBytes.bytes carries raw base64; strip the data-URL prefix.
+              const base64Data = dataUrl.split(",")[1] ?? dataUrl;
 
-            rtvi_file = {
-              format: file.type,
-              source: {
-                type: "bytes",
-                bytes: fileContent,
-              },
-            };
-            await sendFileMessage();
-            resolve();
+              rtvi_file = {
+                name: file.name,
+                format: mimeType,
+                source: {
+                  type: "bytes",
+                  bytes: base64Data,
+                },
+              };
+              await sendFileMessage();
+              resolve();
+            } catch (err) {
+              reject(err);
+            }
           };
 
           reader.readAsDataURL(file);

--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -278,7 +278,7 @@ export type RTVIImageFormat =
   | "webp"
   | "gif"
   | "heic"
-  | "hief";
+  | "heif";
 export type RTVIDocFormat =
   | "pdf"
   | "csv"
@@ -299,7 +299,6 @@ export type RTVIMediaFormat =
   | "aac"
   | "mp4"
   | "webm"
-  | "ogg"
   | "avi";
 export type RTVIFileFormat = RTVIImageFormat | RTVIDocFormat | RTVIMediaFormat;
 
@@ -311,7 +310,7 @@ export const MimeTypeMapping: Record<RTVIFileFormat, string> = {
   webp: "image/webp",
   gif: "image/gif",
   heic: "image/heic",
-  hief: "image/heif",
+  heif: "image/heif",
   // Documents
   pdf: "application/pdf",
   csv: "text/csv",

--- a/package-lock.json
+++ b/package-lock.json
@@ -51,7 +51,7 @@
     },
     "client-react": {
       "name": "@pipecat-ai/client-react",
-      "version": "1.8.0",
+      "version": "1.8.1",
       "license": "BSD-2-Clause",
       "dependencies": {
         "jotai": "^2.9.0"


### PR DESCRIPTION
…ts through).

- FileReader path strips the data-URL prefix so bytes carries raw base64, uses the normalized MIME type, includes the filename, and properly rejects on read errors (previously an unreadable file hung the promise forever).
- sendFile no longer mutates the caller's RTVIFile (spreads a copy).
- messages.ts: "hief" → "heif", removed the duplicate "ogg". Rebuilt client-js — your running example picks up the new dist on refresh, and since the local pipecat branch now advertises 2.2.0, local end-to-end still works.