### PR TITLE
fix(client-react): Fixed issue where mic/cam enabled state could get …

### DIFF
--- a/client-react/src/PipecatClientState.tsx
+++ b/client-react/src/PipecatClientState.tsx
@@ -100,6 +100,25 @@ export const PipecatClientStateProvider: React.FC<React.PropsWithChildren> = ({
     }
   });
 
+  // TrackStarted/Stopped fire for more than an enabled/disabled toggle — a
+  // device switch is Stopped(old)+Started(new) with the enabled state never
+  // conceptually changing, so treating "stopped" as false / "started" as
+  // true would drift from reality whenever those causes interleave. Use the
+  // event purely as a signal to re-check, and read the actual state off the
+  // client (the source of truth) rather than inferring it from which event
+  // fired.
+  useRTVIClientEvent(RTVIEvent.TrackStarted, (track, participant) => {
+    if (!participant?.local || !client) return;
+    if (track.kind === "audio") setIsMicEnabled(client.isMicEnabled ?? false);
+    if (track.kind === "video") setIsCamEnabled(client.isCamEnabled ?? false);
+  });
+
+  useRTVIClientEvent(RTVIEvent.TrackStopped, (track, participant) => {
+    if (!participant?.local || !client) return;
+    if (track.kind === "audio") setIsMicEnabled(client.isMicEnabled ?? false);
+    if (track.kind === "video") setIsCamEnabled(client.isCamEnabled ?? false);
+  });
+
   return (
     <PipecatClientTransportStateContext.Provider value={transportState}>
       <PipecatClientCamStateContext.Provider


### PR DESCRIPTION
…out of sync

the mic/cam can turn off for more than the reason that they were manually turned off via enableCam/Mic, like when the client disconnects or if there's an error. This fix listens for track-started/stopped events to ensure that the provider state remains in sync with the underlying mic/cam state.