### PR TITLE
fix(react): Keep an assistant turn in one message on RTVI 2.0.0

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,7 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": "",
+    "sessionUrl": false
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Claude Code local overrides
+.claude/settings.local.json

--- a/client-react/src/conversation/conversationActions.ts
+++ b/client-react/src/conversation/conversationActions.ts
@@ -295,6 +295,41 @@ export function updateLastMessage(
   set(messagesAtom, processedMessages);
 }
 
+/**
+ * Snap the speech-progress cursor of the last assistant message to the end of
+ * all its parts, marking every part as fully spoken.
+ *
+ * Used on a normal, uninterrupted turn boundary: the bot finished speaking, so
+ * all text should render as "spoken". Without this, text from the last
+ * sentence can remain grey if the spoken BotOutput event didn't match the
+ * unspoken text exactly.
+ *
+ * Deliberately *not* used on the interruption path (UserStartedSpeaking),
+ * where unspoken text should stay unspoken.
+ */
+export function snapSpeechCursorToEnd(get: Getter, set: Setter) {
+  const messages = get(messagesAtom);
+  const last = findLast(
+    messages,
+    (m: ConversationMessage) => m.role === "assistant"
+  );
+  if (!last) return;
+
+  const cursorMap = new Map(get(botOutputMessageStateAtom));
+  const cursor = cursorMap.get(last.createdAt);
+  if (!cursor || !last.parts || last.parts.length === 0) return;
+
+  const lastPartIdx = last.parts.length - 1;
+  const lastPartText = last.parts[lastPartIdx]?.text;
+  cursor.currentPartIndex = lastPartIdx;
+  cursor.currentCharIndex =
+    typeof lastPartText === "string" ? lastPartText.length : 0;
+  for (let i = 0; i <= lastPartIdx; i++) {
+    cursor.partFinalFlags[i] = true;
+  }
+  set(botOutputMessageStateAtom, cursorMap);
+}
+
 export function finalizeLastMessage(
   get: Getter,
   set: Setter,

--- a/client-react/src/conversation/useConversationEventWiring.ts
+++ b/client-react/src/conversation/useConversationEventWiring.ts
@@ -26,6 +26,7 @@ import {
   handleFunctionCallStarted,
   handleFunctionCallStopped,
   removeEmptyLastMessage,
+  snapSpeechCursorToEnd,
   updateAssistantBotOutput,
   updateLastMessage,
   upsertUserTranscript,
@@ -99,7 +100,7 @@ export function useConversationEventWiring() {
       if (lastAssistant && !lastAssistant.final) {
         finalizeLastMessage(get, set, "assistant");
       }
-    }, [])
+    }, [cancelFinalizeTimer])
   );
 
   const ensureAssistantMessage = useAtomCallback(
@@ -166,34 +167,13 @@ export function useConversationEventWiring() {
       botStoppedSpeakingTimeoutRef.current = setTimeout(() => {
         botStoppedSpeakingTimeoutRef.current = undefined;
 
-        // Snap the speech-progress cursor to the end of all parts.
         // The bot finished speaking normally (not interrupted), so all
-        // text should render as "spoken". Without this, text from the
-        // last sentence can remain grey if the spoken BotOutput event
-        // didn't match the unspoken text exactly.
-        const msgs = get(messagesAtom);
-        const cursorMap = new Map(get(botOutputMessageStateAtom));
-        const last = findLast(msgs,
-          (m: ConversationMessage) => m.role === "assistant"
-        );
-        if (last) {
-          const cursor = cursorMap.get(last.createdAt);
-          if (cursor && last.parts && last.parts.length > 0) {
-            const lastPartIdx = last.parts.length - 1;
-            const lastPartText = last.parts[lastPartIdx]?.text;
-            cursor.currentPartIndex = lastPartIdx;
-            cursor.currentCharIndex =
-              typeof lastPartText === "string" ? lastPartText.length : 0;
-            for (let i = 0; i <= lastPartIdx; i++) {
-              cursor.partFinalFlags[i] = true;
-            }
-            set(botOutputMessageStateAtom, cursorMap);
-          }
-        }
+        // text should render as "spoken".
+        snapSpeechCursorToEnd(get, set);
 
         finalizeLastMessage(get, set, "assistant");
       }, BOT_STOPPED_FINALIZE_DELAY_MS);
-    }, [])
+    }, [cancelFinalizeTimer])
   );
 
   // -- event handlers --------------------------------------------------------
@@ -299,6 +279,13 @@ export function useConversationEventWiring() {
               spoken: isSpoken,
             };
 
+            // Deliberately kept, and deliberately asymmetric with the 2.0.0
+            // path above: on 1.4.x an unspoken event precedes the spoken one
+            // for each sentence, so `hasUnspokenContent` is true and
+            // `ensureAssistantMessage` reopens the message rather than
+            // splitting it. The per-sentence `final` is effectively inert
+            // here, so there is no turn-splitting bug to fix on this branch —
+            // and passing `false` would change shipped behavior for nothing.
             const isFinal = data.aggregated_by === "sentence";
             updateAssistantBotOutput(
               get,

--- a/client-react/src/conversation/useConversationEventWiring.ts
+++ b/client-react/src/conversation/useConversationEventWiring.ts
@@ -83,10 +83,15 @@ export function useConversationEventWiring() {
 
   // -- helpers ---------------------------------------------------------------
 
+  /** Cancel any pending delayed finalize, leaving no timer armed. */
+  const cancelFinalizeTimer = useCallback(() => {
+    clearTimeout(botStoppedSpeakingTimeoutRef.current);
+    botStoppedSpeakingTimeoutRef.current = undefined;
+  }, []);
+
   const finalizeLastAssistantMessageIfPending = useAtomCallback(
     useCallback((get, set) => {
-      clearTimeout(botStoppedSpeakingTimeoutRef.current);
-      botStoppedSpeakingTimeoutRef.current = undefined;
+      cancelFinalizeTimer();
       const messages = get(messagesAtom);
       const lastAssistant = findLast(messages,
         (m: ConversationMessage) => m.role === "assistant"
@@ -139,6 +144,58 @@ export function useConversationEventWiring() {
     }, [])
   );
 
+  /**
+   * Arms (or re-arms) the delayed finalize for the in-flight assistant turn.
+   *
+   * Finalizing is deferred rather than immediate because the bot may just be
+   * pausing mid-turn; BotStartedSpeaking cancels the timer when that happens.
+   * On RTVI 2.0.0+ this timer and UserStartedSpeaking are the *only* things
+   * that end an assistant turn, so any path that cancels the timer has to
+   * re-arm it here rather than dropping it on the floor.
+   */
+  const armBotStoppedFinalizeTimer = useAtomCallback(
+    useCallback((get, set) => {
+      cancelFinalizeTimer();
+
+      const messages = get(messagesAtom);
+      const lastAssistant = findLast(messages,
+        (m: ConversationMessage) => m.role === "assistant"
+      );
+      if (!lastAssistant || lastAssistant.final) return;
+
+      botStoppedSpeakingTimeoutRef.current = setTimeout(() => {
+        botStoppedSpeakingTimeoutRef.current = undefined;
+
+        // Snap the speech-progress cursor to the end of all parts.
+        // The bot finished speaking normally (not interrupted), so all
+        // text should render as "spoken". Without this, text from the
+        // last sentence can remain grey if the spoken BotOutput event
+        // didn't match the unspoken text exactly.
+        const msgs = get(messagesAtom);
+        const cursorMap = new Map(get(botOutputMessageStateAtom));
+        const last = findLast(msgs,
+          (m: ConversationMessage) => m.role === "assistant"
+        );
+        if (last) {
+          const cursor = cursorMap.get(last.createdAt);
+          if (cursor && last.parts && last.parts.length > 0) {
+            const lastPartIdx = last.parts.length - 1;
+            const lastPartText = last.parts[lastPartIdx]?.text;
+            cursor.currentPartIndex = lastPartIdx;
+            cursor.currentCharIndex =
+              typeof lastPartText === "string" ? lastPartText.length : 0;
+            for (let i = 0; i <= lastPartIdx; i++) {
+              cursor.partFinalFlags[i] = true;
+            }
+            set(botOutputMessageStateAtom, cursorMap);
+          }
+        }
+
+        finalizeLastMessage(get, set, "assistant");
+      }, BOT_STOPPED_FINALIZE_DELAY_MS);
+    }, [])
+  );
+
   // -- event handlers --------------------------------------------------------
 
   useRTVIClientEvent(
@@ -148,10 +205,9 @@ export function useConversationEventWiring() {
         clearMessages(get, set);
         set(botOutputSupportedAtom, null);
         set(botOutputProtocolAtom, null);
-        clearTimeout(botStoppedSpeakingTimeoutRef.current);
-        botStoppedSpeakingTimeoutRef.current = undefined;
+        cancelFinalizeTimer();
         botOutputLastChunkRef.current = { spoken: "", unspoken: "" };
-      }, [])
+      }, [cancelFinalizeTimer])
     )
   );
 
@@ -180,11 +236,6 @@ export function useConversationEventWiring() {
     useAtomCallback(
       useCallback(
         (get, set, data: BotOutputData) => {
-          // A BotOutput event means the response is still active; cancel any
-          // pending finalize timer from BotStoppedSpeaking.
-          clearTimeout(botStoppedSpeakingTimeoutRef.current);
-          botStoppedSpeakingTimeoutRef.current = undefined;
-
           const protocol = get(botOutputProtocolAtom) ?? "legacy";
 
           if (protocol === "v2") {
@@ -207,12 +258,17 @@ export function useConversationEventWiring() {
               segment_id: data.segment_id,
             };
 
-            const isFinal = data.aggregated_by === "sentence";
+            // `aggregated_by` describes how the text was chunked, not whether
+            // the turn is over: a turn contains many sentences. Marking each
+            // sentence final ends the message after the first one, and the
+            // next segment then opens a new bubble instead of continuing the
+            // turn. On 2.0.0 the turn is finalized by BotStoppedSpeaking (or
+            // by the user starting a new turn), so leave it open here.
             updateAssistantBotOutput(
               get,
               set,
               data.text,
-              isFinal,
+              false,
               payload,
               data.aggregated_by
             );
@@ -253,64 +309,37 @@ export function useConversationEventWiring() {
               data.aggregated_by
             );
           }
+
+          // A BotOutput event means the response is still active, so push a
+          // pending finalize deadline back rather than letting it fire
+          // mid-turn. It is postponed, not dropped: on 2.0.0 nothing else ends
+          // the turn, so cancelling outright for a trailing event would leave
+          // the message non-final until the user speaks again. This handler is
+          // synchronous, so a pending timer cannot have fired before here.
+          // Re-arming is a no-op once the message is final (legacy path).
+          if (botStoppedSpeakingTimeoutRef.current) {
+            armBotStoppedFinalizeTimer();
+          }
         },
-        [ensureAssistantMessage]
+        [armBotStoppedFinalizeTimer, ensureAssistantMessage]
       )
     )
   );
 
   useRTVIClientEvent(
     RTVIEvent.BotStoppedSpeaking,
-    useAtomCallback(
-      useCallback((get, set) => {
-        // Don't finalize immediately; start a timer. Bot may start speaking again (pause).
-        clearTimeout(botStoppedSpeakingTimeoutRef.current);
-        const messages = get(messagesAtom);
-        const lastAssistant = findLast(messages,
-          (m: ConversationMessage) => m.role === "assistant"
-        );
-        if (!lastAssistant || lastAssistant.final) return;
-        botStoppedSpeakingTimeoutRef.current = setTimeout(() => {
-          botStoppedSpeakingTimeoutRef.current = undefined;
-
-          // Snap the speech-progress cursor to the end of all parts.
-          // The bot finished speaking normally (not interrupted), so all
-          // text should render as "spoken". Without this, text from the
-          // last sentence can remain grey if the spoken BotOutput event
-          // didn't match the unspoken text exactly.
-          const msgs = get(messagesAtom);
-          const cursorMap = new Map(get(botOutputMessageStateAtom));
-          const last = findLast(msgs,
-            (m: ConversationMessage) => m.role === "assistant"
-          );
-          if (last) {
-            const cursor = cursorMap.get(last.createdAt);
-            if (cursor && last.parts && last.parts.length > 0) {
-              const lastPartIdx = last.parts.length - 1;
-              const lastPartText = last.parts[lastPartIdx]?.text;
-              cursor.currentPartIndex = lastPartIdx;
-              cursor.currentCharIndex =
-                typeof lastPartText === "string" ? lastPartText.length : 0;
-              for (let i = 0; i <= lastPartIdx; i++) {
-                cursor.partFinalFlags[i] = true;
-              }
-              set(botOutputMessageStateAtom, cursorMap);
-            }
-          }
-
-          finalizeLastMessage(get, set, "assistant");
-        }, BOT_STOPPED_FINALIZE_DELAY_MS);
-      }, [])
-    )
+    useCallback(() => {
+      // Don't finalize immediately; start a timer. Bot may start speaking again (pause).
+      armBotStoppedFinalizeTimer();
+    }, [armBotStoppedFinalizeTimer])
   );
 
   useRTVIClientEvent(
     RTVIEvent.BotStartedSpeaking,
     useCallback(() => {
       // Bot is speaking again; reset the finalize timer (bot was just pausing).
-      clearTimeout(botStoppedSpeakingTimeoutRef.current);
-      botStoppedSpeakingTimeoutRef.current = undefined;
-    }, [])
+      cancelFinalizeTimer();
+    }, [cancelFinalizeTimer])
   );
 
   useRTVIClientEvent(

--- a/client-react/tests/conversation/helpers/storeHarness.ts
+++ b/client-react/tests/conversation/helpers/storeHarness.ts
@@ -135,12 +135,13 @@ export function createStoreHarness() {
       ensureAssistantMessage();
     }
 
-    const isFinal = aggregated_by === "sentence";
+    // v2 never finalizes per segment; the turn is finalized by
+    // BotStoppedSpeaking / UserStartedSpeaking. Mirrors useConversationEventWiring.
     actions.updateAssistantBotOutput(
       store.get,
       store.set,
       text,
-      isFinal,
+      false,
       { protocol: "v2", will_be_spoken, spoken_status, spoken_progress, segment_id },
       aggregated_by
     );
@@ -159,6 +160,38 @@ export function createStoreHarness() {
    */
   function finalizeAssistant() {
     actions.finalizeLastMessage(store.get, store.set, "assistant");
+  }
+
+  /**
+   * Finalize the assistant turn the way the BotStoppedSpeaking timer does:
+   * snap the speech-progress cursor to the end of all parts, then finalize.
+   * Mirrors armBotStoppedFinalizeTimer in useConversationEventWiring.
+   *
+   * Use this for a normal, uninterrupted turn boundary. `finalizeAssistant`
+   * models the raw UserStartedSpeaking / interruption path, which deliberately
+   * does not snap the cursor (unspoken text stays unspoken).
+   */
+  function finalizeAssistantAfterBotStoppedSpeaking() {
+    const messages = store.get(messagesAtom);
+    const cursorMap = new Map(store.get(botOutputMessageStateAtom));
+    const last = [...messages]
+      .reverse()
+      .find((m: ConversationMessage) => m.role === "assistant");
+    if (last) {
+      const cursor = cursorMap.get(last.createdAt);
+      if (cursor && last.parts && last.parts.length > 0) {
+        const lastPartIdx = last.parts.length - 1;
+        const lastPartText = last.parts[lastPartIdx]?.text;
+        cursor.currentPartIndex = lastPartIdx;
+        cursor.currentCharIndex =
+          typeof lastPartText === "string" ? lastPartText.length : 0;
+        for (let i = 0; i <= lastPartIdx; i++) {
+          cursor.partFinalFlags[i] = true;
+        }
+        store.set(botOutputMessageStateAtom, cursorMap);
+      }
+    }
+    finalizeAssistant();
   }
 
   /**
@@ -342,6 +375,7 @@ export function createStoreHarness() {
     emitBotOutputV2,
     emitUserTranscript,
     finalizeAssistant,
+    finalizeAssistantAfterBotStoppedSpeaking,
     finalizeUser,
     finalizeAssistantIfPending,
     finalizeUserIfPending,

--- a/client-react/tests/conversation/helpers/storeHarness.ts
+++ b/client-react/tests/conversation/helpers/storeHarness.ts
@@ -165,32 +165,15 @@ export function createStoreHarness() {
   /**
    * Finalize the assistant turn the way the BotStoppedSpeaking timer does:
    * snap the speech-progress cursor to the end of all parts, then finalize.
-   * Mirrors armBotStoppedFinalizeTimer in useConversationEventWiring.
+   * Calls the same `snapSpeechCursorToEnd` that armBotStoppedFinalizeTimer
+   * uses, so this cannot drift from production.
    *
    * Use this for a normal, uninterrupted turn boundary. `finalizeAssistant`
    * models the raw UserStartedSpeaking / interruption path, which deliberately
    * does not snap the cursor (unspoken text stays unspoken).
    */
   function finalizeAssistantAfterBotStoppedSpeaking() {
-    const messages = store.get(messagesAtom);
-    const cursorMap = new Map(store.get(botOutputMessageStateAtom));
-    const last = [...messages]
-      .reverse()
-      .find((m: ConversationMessage) => m.role === "assistant");
-    if (last) {
-      const cursor = cursorMap.get(last.createdAt);
-      if (cursor && last.parts && last.parts.length > 0) {
-        const lastPartIdx = last.parts.length - 1;
-        const lastPartText = last.parts[lastPartIdx]?.text;
-        cursor.currentPartIndex = lastPartIdx;
-        cursor.currentCharIndex =
-          typeof lastPartText === "string" ? lastPartText.length : 0;
-        for (let i = 0; i <= lastPartIdx; i++) {
-          cursor.partFinalFlags[i] = true;
-        }
-        store.set(botOutputMessageStateAtom, cursorMap);
-      }
-    }
+    actions.snapSpeechCursorToEnd(store.get, store.set);
     finalizeAssistant();
   }
 

--- a/client-react/tests/conversation/integration/botOutputAssembly.test.ts
+++ b/client-react/tests/conversation/integration/botOutputAssembly.test.ts
@@ -653,4 +653,21 @@ describe("BotOutput assembly", () => {
       expect(cursorAfter.currentCharIndex).toBe(absorbedOffset);
     });
   });
+
+  // -----------------------------------------------------------------------
+  // Backwards compatibility (protocol 1.4.x)
+  // -----------------------------------------------------------------------
+  describe("legacy per-sentence finalization", () => {
+    it("still marks a sentence-aggregated message final", () => {
+      harness.emitBotOutput("Hello there.", false, "sentence");
+
+      expect(harness.getMessages()[0].final).toBe(true);
+    });
+
+    it("does not mark non-sentence aggregations final", () => {
+      harness.emitBotOutput("Hello", false, "word");
+
+      expect(harness.getMessages()[0].final).toBeFalsy();
+    });
+  });
 });

--- a/client-react/tests/conversation/integration/eventWiring.test.tsx
+++ b/client-react/tests/conversation/integration/eventWiring.test.tsx
@@ -1,0 +1,236 @@
+/**
+ * Copyright (c) 2026, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import {
+  afterEach,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  jest,
+} from "@jest/globals";
+import { RTVIEvent } from "@pipecat-ai/client-js";
+import { act, render } from "@testing-library/react";
+import { createStore, Provider } from "jotai";
+
+import { messagesAtom } from "@/conversation/conversationAtoms";
+import { PipecatConversationProvider } from "@/conversation/PipecatConversationProvider";
+import type { ConversationMessage } from "@/conversation/types";
+import { RTVIEventContext } from "@/RTVIEventContext";
+
+/**
+ * Renders the real event wiring (via PipecatConversationProvider) against a
+ * fake RTVI event bus, so these tests exercise
+ * `useConversationEventWiring` itself rather than a hand-written mirror of it.
+ */
+function renderWiring() {
+  const store = createStore();
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const handlers = new Map<string, Set<(data?: any) => void>>();
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const on = (event: string, handler: (data?: any) => void) => {
+    if (!handlers.has(event)) handlers.set(event, new Set());
+    handlers.get(event)!.add(handler);
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const off = (event: string, handler: (data?: any) => void) => {
+    handlers.get(event)?.delete(handler);
+  };
+
+  render(
+    <Provider store={store}>
+      <RTVIEventContext.Provider
+        value={{
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          on: on as any,
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          off: off as any,
+        }}
+      >
+        <PipecatConversationProvider>{null}</PipecatConversationProvider>
+      </RTVIEventContext.Provider>
+    </Provider>
+  );
+
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const emit = (event: RTVIEvent, data?: any) => {
+    act(() => {
+      handlers.get(event)?.forEach((handler) => handler(data));
+    });
+  };
+
+  const advance = (ms: number) => {
+    act(() => {
+      jest.advanceTimersByTime(ms);
+    });
+  };
+
+  return {
+    emit,
+    advance,
+    getMessages: () => store.get(messagesAtom),
+    getAssistantMessages: () =>
+      store
+        .get(messagesAtom)
+        .filter((m: ConversationMessage) => m.role === "assistant"),
+  };
+}
+
+/** Delay the wiring waits after BotStoppedSpeaking before finalizing. */
+const FINALIZE_DELAY_MS = 2500;
+
+const sentence = (
+  text: string,
+  segment_id: number,
+  extra: Record<string, unknown> = {}
+) => ({
+  text,
+  aggregated_by: "sentence",
+  will_be_spoken: true,
+  segment_id,
+  ...extra,
+});
+
+describe("useConversationEventWiring", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  describe("RTVI 2.0.0+ turn continuity", () => {
+    /**
+     * Starts a v2 session with the bot mid-turn, having spoken one sentence.
+     */
+    function startV2Turn() {
+      const w = renderWiring();
+      w.emit(RTVIEvent.BotReady, { version: "2.1.0" });
+      w.emit(RTVIEvent.BotStartedSpeaking);
+      w.emit(
+        RTVIEvent.BotOutput,
+        sentence("Hi there!", 1, {
+          spoken_status: "new",
+        })
+      );
+      w.emit(
+        RTVIEvent.BotOutput,
+        sentence("Hi there!", 1, {
+          spoken_status: "completed",
+          spoken_progress: {
+            accumulated_text: "Hi there!",
+            remaining_text: "",
+          },
+        })
+      );
+      return w;
+    }
+
+    it("keeps a multi-sentence turn in a single assistant message", () => {
+      const w = startV2Turn();
+      w.emit(
+        RTVIEvent.BotOutput,
+        sentence("How can I help you today?", 2, {
+          spoken_status: "new",
+        })
+      );
+
+      const assistant = w.getAssistantMessages();
+      expect(assistant).toHaveLength(1);
+      expect(assistant[0].parts.map((p) => p.text)).toEqual([
+        "Hi there!",
+        "How can I help you today?",
+      ]);
+    });
+
+    it("leaves the turn open until BotStoppedSpeaking settles", () => {
+      const w = startV2Turn();
+      expect(w.getAssistantMessages()[0].final).toBeFalsy();
+
+      w.emit(RTVIEvent.BotStoppedSpeaking);
+      w.advance(FINALIZE_DELAY_MS - 1);
+      expect(w.getAssistantMessages()[0].final).toBeFalsy();
+
+      w.advance(1);
+      expect(w.getAssistantMessages()[0].final).toBe(true);
+    });
+
+    it("finalizes the turn when the user interrupts", () => {
+      const w = startV2Turn();
+      w.emit(RTVIEvent.UserStartedSpeaking);
+
+      expect(w.getAssistantMessages()[0].final).toBe(true);
+    });
+
+    it("re-arms the finalize timer for a BotOutput trailing BotStoppedSpeaking", () => {
+      const w = startV2Turn();
+      w.emit(RTVIEvent.BotStoppedSpeaking);
+      w.advance(FINALIZE_DELAY_MS - 500);
+
+      // A late progress event postpones finalization; it must not cancel it
+      // outright, or the turn would stay open until the user speaks again.
+      w.emit(
+        RTVIEvent.BotOutput,
+        sentence("Hi there!", 1, {
+          spoken_status: "completed",
+          spoken_progress: {
+            accumulated_text: "Hi there!",
+            remaining_text: "",
+          },
+        })
+      );
+      w.advance(FINALIZE_DELAY_MS - 1);
+      expect(w.getAssistantMessages()[0].final).toBeFalsy();
+
+      w.advance(1);
+      expect(w.getAssistantMessages()[0].final).toBe(true);
+    });
+
+    it("opens a new message for the turn after a finalized one", () => {
+      const w = startV2Turn();
+      w.emit(RTVIEvent.BotStoppedSpeaking);
+      w.advance(FINALIZE_DELAY_MS);
+
+      w.emit(RTVIEvent.BotStartedSpeaking);
+      w.emit(
+        RTVIEvent.BotOutput,
+        sentence("Second turn.", 2, {
+          spoken_status: "new",
+        })
+      );
+
+      expect(w.getAssistantMessages()).toHaveLength(2);
+    });
+  });
+
+  describe("legacy 1.4.x path", () => {
+    it("still finalizes per sentence", () => {
+      const w = renderWiring();
+      w.emit(RTVIEvent.BotReady, { version: "1.4.0" });
+      w.emit(RTVIEvent.BotOutput, {
+        text: "Hello there.",
+        aggregated_by: "sentence",
+        spoken: true,
+      });
+
+      expect(w.getAssistantMessages()[0].final).toBe(true);
+    });
+
+    it("does not finalize a non-sentence aggregation", () => {
+      const w = renderWiring();
+      w.emit(RTVIEvent.BotReady, { version: "1.4.0" });
+      w.emit(RTVIEvent.BotOutput, {
+        text: "Hello",
+        aggregated_by: "word",
+        spoken: true,
+      });
+
+      expect(w.getAssistantMessages()[0].final).toBeFalsy();
+    });
+  });
+});

--- a/client-react/tests/conversation/stores/botOutputV2.test.ts
+++ b/client-react/tests/conversation/stores/botOutputV2.test.ts
@@ -195,4 +195,41 @@ describe("RTVI Protocol 2.0.0 – BotOutput v2", () => {
       expect(cursor!.hasReceivedUnspoken).toBe(true);
     });
   });
+
+  // -------------------------------------------------------------------------
+  // Turn continuity
+  // -------------------------------------------------------------------------
+  describe("turn continuity", () => {
+    it("keeps one assistant message when a sentence finishes speaking mid-turn", () => {
+      harness.emitBotOutputV2({ text: "Hi there!", will_be_spoken: true, spoken_status: "new", segment_id: 167, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "Hi there!", will_be_spoken: true, spoken_status: "completed", segment_id: 167, aggregated_by: "sentence", spoken_progress: { accumulated_text: "Hi there!", remaining_text: "" } });
+      harness.emitBotOutputV2({ text: "How can I help you today?", will_be_spoken: true, spoken_status: "new", segment_id: 271, aggregated_by: "sentence" });
+
+      const assistant = harness.getMessages().filter((m) => m.role === "assistant");
+      expect(assistant).toHaveLength(1);
+      expect(assistant[0].parts.map((p) => p.text)).toEqual([
+        "Hi there!",
+        "How can I help you today?",
+      ]);
+    });
+
+    it("leaves the turn open until it is explicitly finalized", () => {
+      harness.emitBotOutputV2({ text: "One.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.emitBotOutputV2({ text: "One.", will_be_spoken: true, spoken_status: "completed", segment_id: 1, aggregated_by: "sentence", spoken_progress: { accumulated_text: "One.", remaining_text: "" } });
+
+      expect(harness.getMessages()[0].final).toBeFalsy();
+
+      harness.finalizeAssistant();
+      expect(harness.getMessages()[0].final).toBe(true);
+    });
+
+    it("starts a new assistant message for the next turn after finalization", () => {
+      harness.emitBotOutputV2({ text: "First turn.", will_be_spoken: true, spoken_status: "new", segment_id: 1, aggregated_by: "sentence" });
+      harness.finalizeAssistantAfterBotStoppedSpeaking();
+      harness.emitBotOutputV2({ text: "Second turn.", will_be_spoken: true, spoken_status: "new", segment_id: 2, aggregated_by: "sentence" });
+
+      const assistant = harness.getMessages().filter((m) => m.role === "assistant");
+      expect(assistant).toHaveLength(2);
+    });
+  });
 });


### PR DESCRIPTION
## The bug

On RTVI 2.0.0+, a single assistant turn renders as one bubble per sentence instead of one contiguous block:

```
assistant: Hi there!
assistant: I'm your helpful AI assistant, here to answer your questions...
assistant: How can I help you today?
```

## Cause

`useConversationEventWiring.ts` passed `aggregated_by === "sentence"` as the message's `final` flag. `aggregated_by` describes **how the text was chunked**, not whether the turn is over — a turn contains many sentences — so the message was finalized after its first sentence.

That becomes a visible split through three steps:

1. `updateAssistantBotOutput` applies `final: final ? true : lastMessage.final`, so the bubble is final once sentence 1 lands.
2. Sentence 2 arrives with `spoken_status: "new"` and calls `ensureAssistantMessage`. There is a guard that reopens a prematurely-finalized message, but it requires `hasUnspokenContent`. Sentence 1's `completed` progress event has already flagged every part spoken, so the guard returns false and a new message is added instead.
3. `mergeConsecutiveMessages` cannot rejoin them, because merging requires `!lastMerged.final`.

## Fix

Pass `false` on the 2.0.0 path and let the turn be finalized where turn boundaries are actually known — the `BotStoppedSpeaking` timer, or the user starting a new turn. Both paths already exist and are unchanged.

### Backwards compatibility

The change is scoped to the v2 branch. The 1.4.x branch keeps `aggregated_by === "sentence"` unchanged.

The asymmetry is deliberate: the two protocols reopen a finalized message by different means. On 1.4.x an unspoken event precedes the spoken one for each sentence, so `hasUnspokenContent` is true and `ensureAssistantMessage` reopens the message rather than splitting — the per-sentence `final` is effectively inert there. On 2.0.0 the `completed` progress event flags every part spoken, which is what defeats the guard. Changing 1.4.x too would alter shipped behavior with no bug to justify it.

This reasoning now lives in a comment on the legacy branch itself, so a later cleanup of the "inconsistency" doesn't quietly reintroduce the bug on 1.4.x.

## Testing

**265 tests pass, up from 253 on `main`** — 12 added. Within `tests/conversation` alone that is 212, up from 200.

A failing test was written first, reproducing the reported event sequence (segment #167 `new` → `completed`, then #271 `new`). Before the fix it produced two `final: true` assistant messages; after, one message with parts `["Hi there!", "How can I help you today?"]`.

The added tests cover:

- **v2 turn continuity** — one message when a sentence finishes speaking mid-turn; the turn stays open until explicitly finalized; a genuine turn boundary still starts a new message.
- **Timer re-arming** — a `BotOutput` trailing `BotStoppedSpeaking` pushes the finalize deadline back rather than letting it fire mid-turn.
- **1.4.x compatibility** — a sentence-aggregated message is still marked final; non-sentence aggregations still are not.

`eventWiring.test.tsx` drives the real hook through a fake event bus, rather than reimplementing its logic. The harness-based v2 tests are worth migrating in that direction over time.

`storeHarness.ts` duplicated the same `aggregated_by === "sentence"` logic, so its v2 path was updated to mirror the wiring — otherwise the suite would have kept exercising the old behavior. The harness's legacy `emitBotOutput` is untouched.

Typecheck is clean, as is `eslint` on the changed source files.

## Follow-up: unspoken turns are never finalized (not addressed here)

A v2 turn that is never spoken has no finalize path except `UserStartedSpeaking`, because the `BotOutput` handler only *re-arms* an already-pending timer and `BotStoppedSpeaking` never fires for such a turn. On a text-input-only client with no VAD, `UserStartedSpeaking` never fires either, so the message stays non-final indefinitely.

Two distinct symptoms, only one of which this PR touches:

- **The `final` flag** — new here. Sentence aggregation used to finalize such a turn immediately; now it stays open. Cosmetic: it may render as still in progress.
- **Cross-turn merging** — pre-existing. `ensureAssistantMessage` reopens the finalized message via `hasUnspokenContent`, so two consecutive unspoken turns merge into one bubble. This happens identically on `main`, verified by probing both branches, so it is not a regression.

The follow-up should be scoped to the merging, which is the larger half of the problem; the flag alone would not fix it.
