### PR TITLE
fix(client-js): align ErrorData with server payload

### DIFF
--- a/.commitlintrc.json
+++ b/.commitlintrc.json
@@ -1,7 +1,7 @@
 {
   "extends": ["@commitlint/config-conventional"],
   "rules": {
-    "scope-enum": [2, "always", ["js", "react", ""]],
+    "scope-enum": [2, "always", ["js", "client-js", "react", "client-react", ""]],
     "body-max-line-length": [0],
     "footer-max-line-length": [0],
     "header-case": [0],

--- a/client-js/rtvi/messages.ts
+++ b/client-js/rtvi/messages.ts
@@ -118,8 +118,10 @@ export type ClientReadyData = {
 };
 
 export type ErrorData = {
-  message: string;
+  error: string;
   fatal: boolean;
+  /** @deprecated Use `error` instead. */
+  message?: string;
 };
 
 export type PipecatMetricData = {
@@ -339,6 +341,10 @@ export class RTVIMessage {
   }
 
   static error(message: string, fatal = false): RTVIMessage {
-    return new RTVIMessage(RTVIMessageType.ERROR, { message, fatal });
+    return new RTVIMessage(RTVIMessageType.ERROR, {
+      error: message,
+      message,
+      fatal,
+    });
   }
 }

--- a/client-js/tests/messages.spec.ts
+++ b/client-js/tests/messages.spec.ts
@@ -1,0 +1,32 @@
+/**
+ * Copyright (c) 2024, Daily.
+ *
+ * SPDX-License-Identifier: BSD-2-Clause
+ */
+
+import { describe, expect, test } from "@jest/globals";
+
+import { ErrorData, RTVIMessage, RTVIMessageType } from "../rtvi";
+
+describe("RTVIMessage errors", () => {
+  test("accepts the server error payload", () => {
+    const data: ErrorData = {
+      error: "Server error",
+      fatal: false,
+    };
+
+    const message = new RTVIMessage(RTVIMessageType.ERROR, data);
+
+    expect(message.data).toEqual(data);
+  });
+
+  test("includes the canonical and legacy fields for local errors", () => {
+    const message = RTVIMessage.error("Client error", true);
+
+    expect(message.data).toEqual({
+      error: "Client error",
+      message: "Client error",
+      fatal: true,
+    });
+  });
+});


### PR DESCRIPTION
Fixes #244.

## Summary
- align `ErrorData` with the server's canonical `error` field
- preserve the deprecated `message` field on client-generated errors
- cover server and local error payloads